### PR TITLE
fix isort import order

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,6 @@ test=pytest
 addopts = --verbose --pep8 --isort
 testpaths = tests tilings
 
-[isort]
-known_fist_party = comb_spec_searcher
-
+[tool:isort]
+known_first_party = comb_spec_searcher,permuta,tilings
+default_section = THIRDPARTY


### PR DESCRIPTION
Now classify `permuta`, `comb_spec_searcher` and `tilings` as first party package. They are therefore all grouped in the same block of import statements