### PR TITLE
Move the strategies to tilings

### DIFF
--- a/tests/fixtures/diverse_tiling.py
+++ b/tests/fixtures/diverse_tiling.py
@@ -1,0 +1,24 @@
+import pytest
+
+from permuta import Perm
+from tilings import Obstruction, Requirement, Tiling
+
+
+@pytest.fixture
+def diverse_tiling():
+    """Returns a simple, but diverse tiling.
+
+    The tiling has positive, possibly empty and empty cells and also few
+    requirements and a long obstructions."""
+    return Tiling(
+        obstructions=[Obstruction(Perm((0, 2, 3, 1)),
+                                  [(0, 0), (1, 1), (1, 1), (2, 0)]),
+                      Obstruction(Perm((0, 1)), [(1, 0), (1, 0)]),
+                      Obstruction(Perm((1, 0)), [(1, 0), (1, 0)]),
+                      Obstruction(Perm((0, 1)), [(2, 1), (2, 1)]),
+                      Obstruction(Perm((1, 0)), [(2, 1), (2, 1)])],
+        requirements=[[Requirement(Perm((0, 2, 1)), [(0, 1), (0, 2), (1, 2)]),
+                       Requirement(Perm((1, 0)), [(0, 2), (0, 1)])],
+                      [Requirement(Perm((0,)), [(1, 0)])],
+                      [Requirement(Perm((0,)), [(2, 0)])],
+                      [Requirement(Perm((0,)), [(2, 1)])]])

--- a/tests/fixtures/no_point_tiling.py
+++ b/tests/fixtures/no_point_tiling.py
@@ -1,0 +1,20 @@
+import pytest
+
+from permuta import Perm
+from tilings import Obstruction, Requirement, Tiling
+
+
+@pytest.fixture
+def no_point_tiling():
+    """Returns a simple tiling with length of all obs and reqs at least 2. """
+    return Tiling(
+        obstructions=[Obstruction(Perm((1, 0)), [(0, 1), (0, 1)]),
+                      Obstruction(Perm((0, 1, 2)), [(0, 0), (1, 0), (1, 0)]),
+                      Obstruction(Perm((0, 1, 2)), [(1, 0), (1, 0), (2, 0)]),
+                      Obstruction(Perm((0, 2, 1)), [(0, 2), (0, 2), (1, 2)]),
+                      Obstruction(Perm((0, 2, 1)), [(0, 2), (1, 2), (1, 2)])],
+        requirements=[[Requirement(Perm((0, 1)), [(0, 0), (0, 0)]),
+                       Requirement(Perm((0, 1)), [(0, 0), (2, 0)])],
+                      [Requirement(Perm((0, 2, 1)), [(0, 1), (1, 1), (1, 1)])],
+                      [Requirement(Perm((0, 1)), [(1, 1), (2, 1)]),
+                       Requirement(Perm((0, 1)), [(1, 1), (2, 2)])]])

--- a/tests/fixtures/obstructions_requirements.py
+++ b/tests/fixtures/obstructions_requirements.py
@@ -1,0 +1,88 @@
+import pytest
+
+from permuta import Perm
+from tilings import Obstruction, Requirement
+
+
+@pytest.fixture
+def typical_redundant_obstructions():
+    """Returns a very typical list of obstructions clustered together in a
+    corner of a tiling.  """
+    return [
+        Obstruction(Perm((0, 1)), ((1, 0), (1, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (2, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (3, 0))),
+        Obstruction(Perm((0, 1)), ((2, 0), (2, 0))),
+        Obstruction(Perm((0, 1)), ((2, 0), (3, 0))),
+        Obstruction(Perm((0, 1)), ((3, 1), (3, 1))),
+        Obstruction(Perm((1, 0)), ((3, 0), (3, 0))),
+        Obstruction(Perm((1, 0)), ((3, 1), (3, 0))),
+        Obstruction(Perm((1, 0)), ((3, 1), (3, 1))),
+        Obstruction(Perm((0, 1, 2)), ((3, 0), (3, 0), (3, 0))),
+        Obstruction(Perm((0, 1, 2)), ((3, 0), (3, 0), (3, 1))),
+        Obstruction(Perm((2, 1, 0)), ((1, 0), (1, 0), (1, 0))),
+        Obstruction(Perm((2, 1, 0)), ((1, 0), (1, 0), (2, 0))),
+        Obstruction(Perm((2, 1, 0)), ((1, 0), (1, 0), (3, 0))),
+        Obstruction(Perm((2, 1, 0)), ((1, 0), (2, 0), (2, 0))),
+        Obstruction(Perm((2, 1, 0)), ((1, 0), (2, 0), (3, 0))),
+        Obstruction(Perm((2, 1, 0)), ((2, 0), (2, 0), (2, 0))),
+        Obstruction(Perm((2, 1, 0)), ((2, 0), (2, 0), (3, 0))),
+        Obstruction(Perm((3, 2, 1, 0)), ((1, 1), (2, 0), (2, 0), (2, 0))),
+        Obstruction(Perm((3, 2, 1, 0)), ((2, 1), (2, 1), (3, 0), (3, 0)))
+    ]
+
+
+@pytest.fixture
+def typical_redundant_requirements():
+    """Returns a very typical list of requirements of a tiling.  """
+    return [
+        [Requirement(Perm((0, 1, 2)), ((0, 0), (1, 0), (2, 3))),
+         Requirement(Perm((0, 1, 2)), ((0, 0), (1, 0), (2, 4))),
+         Requirement(Perm((1, 0, 2)), ((0, 0), (1, 0), (2, 3))),
+         Requirement(Perm((1, 0, 2)), ((0, 1), (1, 0), (2, 3)))],
+        [Requirement(Perm((0, 1, 2)), ((2, 3), (2, 3), (2, 3))),
+         Requirement(Perm((1, 0, 2)), ((0, 0), (0, 0), (0, 0))),
+         Requirement(Perm((0, 1, 2)), ((1, 0), (1, 0), (1, 0)))],
+        [Requirement(Perm((0, 1)), ((1, 0), (3, 0))),
+         Requirement(Perm((0, 1)), ((2, 0), (2, 0))),
+         Requirement(Perm((0, 1)), ((2, 0), (3, 0))),
+         Requirement(Perm((0, 1)), ((2, 0), (3, 1)))],
+        [Requirement(Perm((1, 0)), ((3, 3), (3, 1))),
+         Requirement(Perm((1, 0)), ((3, 1), (3, 1))),
+         Requirement(Perm((1, 0)), ((3, 1), (3, 0)))]]
+
+
+@pytest.fixture
+def typical_obstructions_with_local():
+    return [
+        Obstruction(Perm((0, 1)), ((1, 0), (1, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (2, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (3, 0))),
+        Obstruction(Perm((0, 1)), ((2, 0), (2, 0))),
+        Obstruction(Perm((0, 1)), ((2, 0), (3, 0))),
+        Obstruction(Perm((0, 1)), ((3, 1), (3, 1))),
+        Obstruction(Perm((0, 2, 1)), ((3, 0), (3, 0), (3, 0))),
+        Obstruction(Perm((0, 1, 2)), ((3, 0), (3, 0), (3, 1))),
+        Obstruction(Perm((1, 2, 0)), ((1, 0), (1, 0), (1, 0))),
+
+        Obstruction(Perm((3, 2, 1, 0)), ((1, 1), (2, 0), (2, 0), (2, 0))),
+        Obstruction(Perm((3, 2, 1, 0)), ((2, 1), (2, 1), (3, 0), (3, 0)))
+    ]
+
+
+@pytest.fixture
+def typical_requirements_with_local():
+    """Return a very typical list of requirements of a tiling, including some
+    local length 1 requirements."""
+    return [
+        [Requirement(Perm((0, 1, 2)), ((0, 0), (1, 0), (2, 3))),
+         Requirement(Perm((0, 1, 2)), ((0, 0), (1, 0), (2, 4))),
+         Requirement(Perm((1, 0, 2)), ((0, 0), (1, 0), (2, 3))),
+         Requirement(Perm((1, 0, 2)), ((0, 1), (1, 0), (2, 3)))],
+        [Requirement(Perm((0, 1)), ((1, 0), (3, 0))),
+         Requirement(Perm((0, 1)), ((2, 0), (2, 0))),
+         Requirement(Perm((0, 1)), ((2, 0), (3, 0))),
+         Requirement(Perm((0, 1)), ((2, 0), (3, 1)))],
+        [Requirement(Perm((0, )), ((3, 0),))],
+        [Requirement(Perm((1, 0)), ((2, 0), (2, 0)))],
+        [Requirement(Perm((0, 2, 1)), ((0, 0), (2, 3), (2, 3)))]]

--- a/tests/fixtures/simple_tiling.py
+++ b/tests/fixtures/simple_tiling.py
@@ -1,0 +1,12 @@
+import pytest
+
+from permuta import Perm
+from tilings import Obstruction, Requirement, Tiling
+
+
+@pytest.fixture
+def simple_tiling():
+    return Tiling(
+        obstructions=[Obstruction(Perm((1, 0)), [(0, 1), (1, 0)])],
+        requirements=[[Requirement(Perm((0, 1)), [(0, 0), (1, 0)]),
+                       Requirement(Perm((0, 1)), [(0, 0), (1, 1)])]])

--- a/tests/fixtures/simple_trans.py
+++ b/tests/fixtures/simple_trans.py
@@ -1,0 +1,38 @@
+import pytest
+
+from permuta import Perm
+from tilings import Obstruction, Requirement, Tiling
+
+
+@pytest.fixture
+def simple_trans_row():
+    return Tiling(obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (1, 0)]),
+                                Obstruction(Perm((0, 1)), [(1, 0), (2, 0)])],
+                  requirements=[[Requirement(Perm((0,)), [(1, 0)])]])
+
+
+@pytest.fixture
+def simple_trans_col():
+    return Tiling(obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (0, 1)]),
+                                Obstruction(Perm((0, 1)), [(0, 1), (0, 2)])],
+                  requirements=[[Requirement(Perm((0,)), [(0, 1)])]])
+
+
+@pytest.fixture
+def simple_trans_row_len2():
+    return Tiling(obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (1, 0)]),
+                                Obstruction(Perm((0, 1)), [(1, 0), (2, 0)]),
+                                Obstruction(Perm((0, 1)), [(2, 0), (3, 0)])],
+                  requirements=[[Requirement(Perm((0,)), [(1, 0)])],
+                                [Requirement(Perm((0,)), [(2, 0)])]])
+
+
+@pytest.fixture
+def simple_trans_row_len3():
+    return Tiling(obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (1, 0)]),
+                                Obstruction(Perm((0, 1)), [(1, 0), (2, 0)]),
+                                Obstruction(Perm((0, 1)), [(2, 0), (3, 0)]),
+                                Obstruction(Perm((0, 1)), [(3, 0), (4, 0)])],
+                  requirements=[[Requirement(Perm((0,)), [(1, 0)])],
+                                [Requirement(Perm((0,)), [(2, 0)])],
+                                [Requirement(Perm((0,)), [(3, 0)])]])

--- a/tests/strategies/test_batch.py
+++ b/tests/strategies/test_batch.py
@@ -1,0 +1,315 @@
+from permuta import Perm
+from tilings import Obstruction, Requirement, Tiling
+from tilings.strategies.batch import (all_cell_insertions, all_col_insertions,
+                                      all_factor_insertions,
+                                      all_requirement_extensions,
+                                      all_requirement_insertions,
+                                      all_row_insertions,
+                                      requirement_corroboration)
+
+pytest_plugins = [
+    'tests.fixtures.obstructions_requirements',
+    'tests.fixtures.simple_tiling'
+]
+
+
+def test_all_cell_insertions_points(simple_tiling):
+    strats = set([tuple(s.comb_classes)
+                  for s in all_cell_insertions(simple_tiling, maxreqlen=1)])
+    assert all(len(s) == 2 for s in strats)
+    actual = set()
+    actual.add((Tiling(
+        obstructions=[Obstruction(Perm((0,)), [(0, 1)])],
+        requirements=[[Requirement(Perm((0, 1)), [(0, 0), (1, 0)]),
+                       Requirement(Perm((0, 1)), [(0, 0), (1, 1)])]]),
+                Tiling(
+        obstructions=[Obstruction(Perm((0,)), [(1, 0)])],
+        requirements=[[Requirement(Perm((0,)), [(0, 1)])],
+                      [Requirement(Perm((0, 1)), [(0, 0), (1, 1)])]])))
+
+    actual.add((Tiling(
+        obstructions=[Obstruction(Perm((0,)), ((0, 1),)),
+                      Obstruction(Perm((0,)), ((1, 0),))],
+        requirements=[[Requirement(Perm((0, 1)), ((0, 0), (1, 1)))]]),
+        Tiling(
+        obstructions=[Obstruction(Perm((0,)), ((0, 1),))],
+        requirements=[[Requirement(Perm((0,)), ((1, 0),))],
+                      [Requirement(Perm((0, 1)), ((0, 0), (1, 0))),
+                       Requirement(Perm((0, 1)), ((0, 0), (1, 1)))]])))
+
+    actual.add((Tiling(obstructions=[Obstruction(Perm(tuple()), tuple())]),
+                Tiling(
+        obstructions=[Obstruction(Perm((1, 0)), ((0, 1), (1, 0)))],
+        requirements=[[Requirement(Perm((0,)), ((0, 0),))],
+                      [Requirement(Perm((0, 1)), ((0, 0), (1, 0))),
+                       Requirement(Perm((0, 1)), ((0, 0), (1, 1)))]])))
+
+    actual.add((Tiling(
+        requirements=[[Requirement(Perm((0, 1)), ((0, 0), (1, 0)))]]),
+        Tiling(
+        obstructions=[Obstruction(Perm((1, 0)), ((0, 1), (1, 0)))],
+        requirements=[[Requirement(Perm((0,)), ((1, 1),))],
+                      [Requirement(Perm((0, 1)), ((0, 0), (1, 0))),
+                       Requirement(Perm((0, 1)), ((0, 0), (1, 1)))]])))
+    print(simple_tiling)
+    assert strats == actual
+
+
+def test_all_cell_insertions(typical_redundant_requirements,
+                             typical_redundant_obstructions):
+    tiling = Tiling(obstructions=typical_redundant_obstructions,
+                    requirements=typical_redundant_requirements)
+    strats = set([tuple(s.comb_classes)
+                  for s in all_cell_insertions(tiling, maxreqlen=3)])
+    assert all(len(s) == 2 for s in strats)
+    assert ((Tiling(
+        obstructions=typical_redundant_obstructions + [
+            Obstruction(Perm((0, 1, 2)), [(0, 1), (0, 1), (0, 1)])],
+        requirements=typical_redundant_requirements),
+        Tiling(
+        obstructions=typical_redundant_obstructions,
+        requirements=typical_redundant_requirements + [
+            [Requirement(Perm((0, 1, 2)), [(0, 1), (0, 1), (0, 1)])]])
+    ) in strats)
+
+
+def test_all_requirement_extension():
+    t = Tiling.from_string('123_132').add_single_cell_requirement(
+        Perm((0, 1)), (0, 0))
+    strats = set([tuple(s.comb_classes)
+                  for s in all_requirement_extensions(t, maxreqlen=3)])
+    actual = set([
+        (t.add_single_cell_obstruction(Perm((2, 0, 1)), (0, 0)),
+         t.add_single_cell_requirement(Perm((2, 0, 1)), (0, 0))),
+        (t.add_single_cell_obstruction(Perm((1, 0, 2)), (0, 0)),
+         t.add_single_cell_requirement(Perm((1, 0, 2)), (0, 0))),
+        (t.add_single_cell_obstruction(Perm((1, 2, 0)), (0, 0)),
+         t.add_single_cell_requirement(Perm((1, 2, 0)), (0, 0))),
+    ])
+    assert actual == strats
+
+
+def test_all_row_insertion():
+    t = Tiling(obstructions=[
+        Obstruction(Perm((0, 1)), ((0, 0),)*2),
+        Obstruction(Perm((0, 1)), ((1, 0),)*2),
+        Obstruction(Perm((0, 1, 2)), ((0, 1),)*3),
+    ], requirements=[
+        [Requirement(Perm((0, 1)), ((0, 1),)*2)]
+    ])
+    strats = set([tuple(s.comb_classes)
+                  for s in all_row_insertions(t)])
+    actual = set([
+        (Tiling(obstructions=[Obstruction(Perm((0, 1, 2)), ((0, 0),)*3)],
+                requirements=[[Requirement(Perm((0, 1)), ((0, 0),)*2)]]),
+         t.add_list_requirement([Requirement(Perm((0,)), ((0, 0),)),
+                                 Requirement(Perm((0,)), ((1, 0),)), ])), ])
+    assert actual == strats
+    assert (next(all_row_insertions(t)).formal_step ==
+            'Either row 0 is empty or not.')
+
+
+def test_all_col_insertion():
+    t = Tiling(obstructions=[
+        Obstruction(Perm((0, 1)), ((0, 0),)*2),
+        Obstruction(Perm((0, 1)), ((1, 0),)*2),
+        Obstruction(Perm((0, 1, 2)), ((0, 1),)*3),
+    ], requirements=[
+        [Requirement(Perm((0, 1)), ((0, 1),)*2)]
+    ])
+    strats = set([tuple(s.comb_classes)
+                  for s in all_col_insertions(t)])
+    actual = set([
+        (t.add_single_cell_obstruction(Perm((0,)), (1, 0)),
+         t.add_single_cell_requirement(Perm((0,)), (1, 0)),)
+    ])
+    assert actual == strats
+    assert (next(all_col_insertions(t)).formal_step ==
+            'Either column 1 is empty or not.')
+
+
+def test_all_requirement_insertion():
+    t = Tiling(obstructions=[
+        Obstruction(Perm((0, 1)), ((0, 0), (0, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (1, 0))),
+        Obstruction(Perm((0, 1)), ((0, 0), (1, 0))),
+    ])
+    strats = set(tuple(s.comb_classes)
+                 for s in all_requirement_insertions(t, 2))
+    assert len(strats) == 5
+    strat_formal_steps = (
+        set(s.formal_step for s in all_requirement_insertions(t, 2)))
+    assert 'Insert 0 in cell (1, 0).' in strat_formal_steps
+    assert 'Insert 10: (0, 0), (1, 0).' in strat_formal_steps
+
+
+def test_all_factor_insertions():
+    t = Tiling(obstructions=[
+        Obstruction(Perm((0, 1)), ((0, 0), (0, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (1, 0))),
+        Obstruction(Perm((1, 0)), ((1, 1), (1, 1))),
+        Obstruction(Perm((1, 0)), ((1, 2), (1, 2))),
+        Obstruction(Perm((0, 1, 2)), ((0, 0), (1, 1), (1, 2))),
+        Obstruction(Perm((0, 1)), ((0, 0), (1, 0))),
+    ])
+    strats = set(tuple(s.comb_classes)
+                 for s in all_factor_insertions(t))
+    assert len(strats) == 2
+    strat_formal_steps = (
+        set(s.formal_step for s in all_factor_insertions(t)))
+    assert 'Insert 0 in cell (0, 0).' in strat_formal_steps
+    assert 'Insert 01: (1, 1), (1, 2).' in strat_formal_steps
+
+
+def test_requirement_corroboration(typical_redundant_requirements,
+                                   typical_redundant_obstructions):
+    tiling = Tiling(
+        obstructions=[Obstruction(Perm((1, 0)), [(0, 1), (1, 0)])],
+        requirements=[[Requirement(Perm((0, 1)), [(0, 0), (1, 0)]),
+                       Requirement(Perm((0, 1)), [(0, 0), (1, 1)])]])
+    reqins = list(strat.comb_classes
+                  for strat in requirement_corroboration(tiling, None))
+    assert len(reqins) == 2
+    strat1, strat2 = reqins
+
+    assert len(strat1) == 2
+    til1, til2 = strat1
+    assert til1 == Tiling(
+        obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (1, 0)]),
+                      Obstruction(Perm((1, 0)), [(0, 1), (1, 0)])],
+        requirements=[[Requirement(Perm((0,)), [(0, 0)])],
+                      [Requirement(Perm((0,)), [(1, 1)])]])
+    assert til2 == Tiling(
+        obstructions=[],
+        requirements=[[Requirement(Perm((0, 1)), [(0, 0), (1, 0)])]])
+
+    tiling = Tiling(
+        obstructions=typical_redundant_obstructions,
+        requirements=typical_redundant_requirements)
+    reqins = list(strat.comb_classes
+                  for strat in requirement_corroboration(tiling, None))
+    assert len(reqins) == sum(len(reqs) for reqs in tiling.requirements
+                              if len(reqs) > 1)
+    til1, til2 = reqins[0]
+    assert (set([til1, til2]) == set([
+        Tiling(requirements=[
+            [Requirement(Perm((0, 1)), ((2, 0), (3, 1)))],
+            [Requirement(Perm((1, 0)), ((3, 2), (3, 1)))],
+            [Requirement(Perm((0, 1, 2)), ((0, 0), (1, 0), (2, 2)))],
+            [Requirement(Perm((0, 1, 2)), ((2, 2), (2, 2), (2, 2))),
+             Requirement(Perm((1, 0, 2)), ((0, 0), (0, 0), (0, 0)))]],
+            obstructions=typical_redundant_obstructions),
+        Tiling(requirements=[
+            [Requirement(Perm((0, 1)), ((2, 0), (3, 1)))],
+            [Requirement(Perm((1, 0)), ((3, 2), (3, 1)))],
+            [Requirement(Perm((0, 1, 2)), ((0, 0), (1, 0), (2, 3))),
+             Requirement(Perm((1, 0, 2)), ((0, 0), (1, 0), (2, 2))),
+             Requirement(Perm((1, 0, 2)), ((0, 1), (1, 0), (2, 2)))],
+            [Requirement(Perm((0, 1, 2)), ((2, 2), (2, 2), (2, 2))),
+             Requirement(Perm((1, 0, 2)), ((0, 0), (0, 0), (0, 0)))]],
+            obstructions=(typical_redundant_obstructions +
+                          [Obstruction(Perm((0, 1, 2)),
+                                       ((0, 0), (1, 0), (2, 2)))]))]))
+
+
+def test_requirement_extensions(typical_obstructions_with_local,
+                                typical_requirements_with_local):
+    tiling = Tiling(obstructions=typical_obstructions_with_local,
+                    requirements=typical_requirements_with_local)
+    strats = set([frozenset(s.comb_classes)
+                  for s in all_requirement_extensions(tiling, maxreqlen=3)])
+
+    actual = set([
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((0, 1)), (0, 0)),
+            tiling.add_single_cell_requirement(Perm((0, 1)), (0, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((1, 0)), (0, 0)),
+            tiling.add_single_cell_requirement(Perm((1, 0)), (0, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((0, 1, 2)), (0, 0)),
+            tiling.add_single_cell_requirement(Perm((0, 1, 2)), (0, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((0, 2, 1)), (0, 0)),
+            tiling.add_single_cell_requirement(Perm((0, 2, 1)), (0, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((1, 0, 2)), (0, 0)),
+            tiling.add_single_cell_requirement(Perm((1, 0, 2)), (0, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((1, 2, 0)), (0, 0)),
+            tiling.add_single_cell_requirement(Perm((1, 2, 0)), (0, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((2, 0, 1)), (0, 0)),
+            tiling.add_single_cell_requirement(Perm((2, 0, 1)), (0, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((2, 1, 0)), (0, 0)),
+            tiling.add_single_cell_requirement(Perm((2, 1, 0)), (0, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((1, 0)), (3, 1)),
+            tiling.add_single_cell_requirement(Perm((1, 0)), (3, 1))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((2, 1, 0)), (3, 1)),
+            tiling.add_single_cell_requirement(Perm((2, 1, 0)), (3, 1))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((2, 1, 0)), (2, 0)),
+            tiling.add_single_cell_requirement(Perm((2, 1, 0)), (2, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((0, 2, 1)), (2, 2)),
+            tiling.add_single_cell_requirement(Perm((0, 2, 1)), (2, 2))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((1, 0, 2)), (2, 2)),
+            tiling.add_single_cell_requirement(Perm((1, 0, 2)), (2, 2))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((1, 2, 0)), (2, 2)),
+            tiling.add_single_cell_requirement(Perm((1, 2, 0)), (2, 2))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((2, 0, 1)), (2, 2)),
+            tiling.add_single_cell_requirement(Perm((2, 0, 1)), (2, 2))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((2, 1, 0)), (2, 2)),
+            tiling.add_single_cell_requirement(Perm((2, 1, 0)), (2, 2))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((0, 1)), (3, 0)),
+            tiling.add_single_cell_requirement(Perm((0, 1)), (3, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((1, 0)), (3, 0)),
+            tiling.add_single_cell_requirement(Perm((1, 0)), (3, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((0, 1, 2)), (3, 0)),
+            tiling.add_single_cell_requirement(Perm((0, 1, 2)), (3, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((1, 0, 2)), (3, 0)),
+            tiling.add_single_cell_requirement(Perm((1, 0, 2)), (3, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((1, 2, 0)), (3, 0)),
+            tiling.add_single_cell_requirement(Perm((1, 2, 0)), (3, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((2, 0, 1)), (3, 0)),
+            tiling.add_single_cell_requirement(Perm((2, 0, 1)), (3, 0))
+        ]),
+        frozenset([
+            tiling.add_single_cell_obstruction(Perm((2, 1, 0)), (3, 0)),
+            tiling.add_single_cell_requirement(Perm((2, 1, 0)), (3, 0))
+        ])])
+    assert strats == actual

--- a/tests/strategies/test_decomposition.py
+++ b/tests/strategies/test_decomposition.py
@@ -1,0 +1,83 @@
+from permuta import Perm
+from tilings import Obstruction, Requirement, Tiling
+from tilings.algorithms import (Factor, FactorWithInterleaving,
+                                FactorWithMonotoneInterleaving)
+from tilings.strategies.decomposition import (factor, factor_with_interleaving,
+                                              general_factor)
+
+pytest_plugins = [
+    'tests.fixtures.simple_tiling',
+    'tests.fixtures.diverse_tiling',
+    'tests.fixtures.no_point_tiling',
+]
+
+
+def test_general_factor(simple_tiling, diverse_tiling):
+    assert len(list(general_factor(simple_tiling, Factor))) == 0
+    assert (len(list(general_factor(simple_tiling,
+                                    FactorWithMonotoneInterleaving))) == 0)
+    assert (len(list(general_factor(simple_tiling,
+                                    FactorWithInterleaving))) == 0)
+    assert (len(list(general_factor(diverse_tiling,
+                                    FactorWithInterleaving))) == 1)
+    # Test union param
+    strats = list(general_factor(diverse_tiling,
+                                 FactorWithInterleaving,
+                                 union=True))
+    assert len(strats) == 14
+    assert sum(1 for s in strats if 'unions' in s.formal_step) == 13
+    assert sum(1 for s in strats if all(s.workable)) == 1
+    assert sum(1 for s in strats if not any(s.workable)) == 13
+    # Test union param with workable to False
+    strats = list(general_factor(diverse_tiling,
+                                 FactorWithInterleaving,
+                                 union=True,
+                                 workable=False))
+    assert sum(1 for s in strats if all(s.workable)) == 0
+    assert sum(1 for s in strats if not any(s.workable)) == 14
+    # Test union param with workable to True
+    strats = list(general_factor(diverse_tiling,
+                                 FactorWithInterleaving,
+                                 union=True,
+                                 workable=True))
+    assert sum(1 for s in strats if all(s.workable)) == 1
+    assert sum(1 for s in strats if not any(s.workable)) == 13
+
+
+def test_factor_no_unions(simple_tiling,
+                          diverse_tiling,
+                          no_point_tiling):
+    assert len(list(factor(simple_tiling))) == 0
+    assert len(list(factor(diverse_tiling))) == 0
+    tiling = Tiling(
+        obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (0, 0)])],
+        requirements=[[Requirement(Perm((0, 1)), [(1, 1), (1, 1)]),
+                       Requirement(Perm((0, 1)), [(1, 1), (1, 2)])]])
+    strats = [s.comb_classes for s in factor(tiling)]
+    assert len(strats) == 1
+    factors = strats[0]
+    assert set(factors) == set([
+        Tiling(requirements=[[Requirement(Perm((0, 1)), [(0, 0), (0, 0)]),
+                              Requirement(Perm((0, 1)), [(0, 0), (0, 1)])]]),
+        Tiling(obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (0, 0)])])])
+
+    strats = [s.comb_classes
+              for s in factor_with_interleaving(diverse_tiling)]
+    assert len(strats) == 1
+    factors = strats[0]
+    assert len(factors) == 4
+    print(diverse_tiling)
+
+    assert set(factors) == set([
+        Tiling(obstructions=[Obstruction(Perm((0, 2, 3, 1)),
+                                         [(0, 0), (1, 1), (1, 1), (2, 0)])],
+               requirements=[[Requirement(Perm((0,)), [(2, 0)])]]),
+        Tiling(obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (0, 0)]),
+                             Obstruction(Perm((1, 0)), [(0, 0), (0, 0)])],
+               requirements=[[Requirement(Perm((0,)), [(0, 0)])]]),
+        Tiling(obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (0, 0)]),
+                             Obstruction(Perm((1, 0)), [(0, 0), (0, 0)])],
+               requirements=[[Requirement(Perm((0,)), [(0, 0)])]]),
+        Tiling(requirements=[[Requirement(Perm((1, 0)), [(0, 2), (0, 1)]),
+                              Requirement(Perm((0, 2, 1)),
+                                          [(0, 1), (0, 2), (1, 2)])]])])

--- a/tests/strategies/test_equivalence.py
+++ b/tests/strategies/test_equivalence.py
@@ -1,0 +1,169 @@
+
+import pytest
+
+from comb_spec_searcher import Rule
+from permuta import Perm
+from permuta.misc import DIR_EAST, DIR_NORTH, DIR_SOUTH, DIR_WEST, DIRS
+from tilings import Obstruction, Requirement, Tiling
+from tilings.strategies.equivalence import (point_placement,
+                                            requirement_placement)
+
+pytest_plugins = [
+    'tests.fixtures.obstructions_requirements',
+    'tests.fixtures.simple_tiling',
+    'tests.fixtures.diverse_tiling',
+    'tests.fixtures.no_point_tiling'
+]
+
+
+def test_point_placement(diverse_tiling, no_point_tiling):
+    strats = list(point_placement(diverse_tiling))
+    assert len(strats) == 5 * len(DIRS)
+    strats = list(requirement_placement(no_point_tiling))
+    assert len(strats) == 9 * len(DIRS)
+    strats = list(point_placement(no_point_tiling))
+    assert len(strats) == 3 * len(DIRS)
+
+
+def test_place_point_of_requirement_point_only(diverse_tiling):
+    tiling = diverse_tiling.place_point_of_gridded_permutation(
+                                diverse_tiling.requirements[0][0], 0, DIR_WEST)
+    assert tiling == Tiling(
+        obstructions=[
+            Obstruction(Perm((0,)), [(1, 0)]),
+            Obstruction(Perm((0,)), [(1, 2)]),
+            Obstruction(Perm((0,)), [(2, 0)]),
+            Obstruction(Perm((0,)), [(2, 2)]),
+            Obstruction(Perm((0, 1)), [(2, 1), (2, 1)]),
+            Obstruction(Perm((0, 1)), [(4, 3), (4, 3)]),
+            Obstruction(Perm((1, 0)), [(2, 1), (2, 1)]),
+            Obstruction(Perm((1, 0)), [(4, 3), (4, 3)]),
+            Obstruction(Perm((0, 2, 3, 1)), [(0, 0), (1, 3), (1, 3), (4, 0)]),
+            Obstruction(Perm((0, 2, 3, 1)), [(0, 0), (1, 3), (1, 3), (4, 2)]),
+            Obstruction(Perm((0, 2, 3, 1)), [(0, 0), (1, 3), (3, 3), (4, 0)]),
+            Obstruction(Perm((0, 2, 3, 1)), [(0, 0), (1, 3), (3, 3), (4, 2)]),
+            Obstruction(Perm((0, 2, 3, 1)), [(0, 0), (3, 3), (3, 3), (4, 0)]),
+            Obstruction(Perm((0, 2, 3, 1)), [(0, 0), (3, 3), (3, 3), (4, 2)]),
+            Obstruction(Perm((0, 2, 3, 1)), [(0, 2), (1, 3), (1, 3), (4, 2)]),
+            Obstruction(Perm((0, 2, 3, 1)), [(0, 2), (1, 3), (3, 3), (4, 2)]),
+            Obstruction(Perm((0, 2, 3, 1)), [(0, 2), (3, 3), (3, 3), (4, 2)])],
+        requirements=[
+            [Requirement(Perm((0,)), [(2, 1)])],
+            [Requirement(Perm((0,)), [(4, 3)])],
+            [Requirement(Perm((0,)), [(4, 0)]),
+             Requirement(Perm((0,)), [(4, 2)])],
+            [Requirement(Perm((1, 0)), [(0, 4), (0, 3)]),
+             Requirement(Perm((0, 2, 1)), [(0, 3), (0, 4), (1, 4)]),
+             Requirement(Perm((0, 2, 1)), [(0, 3), (0, 4), (3, 4)])]])
+
+    assert tiling == diverse_tiling.place_point_of_gridded_permutation(
+                            diverse_tiling.requirements[0][0], 0, DIR_EAST)
+    assert tiling == diverse_tiling.place_point_of_gridded_permutation(
+                            diverse_tiling.requirements[0][0], 0, DIR_NORTH)
+    assert tiling == diverse_tiling.place_point_of_gridded_permutation(
+                            diverse_tiling.requirements[0][0], 0, DIR_SOUTH)
+
+    print(Tiling(
+        obstructions=[
+            Obstruction(Perm((0,)), [(2, 0)]),
+            Obstruction(Perm((0,)), [(2, 2)]),
+            Obstruction(Perm((0, 1)), [(1, 0), (1, 0)]),
+            Obstruction(Perm((0, 1)), [(1, 0), (1, 2)]),
+            Obstruction(Perm((0, 1)), [(1, 2), (1, 2)]),
+            Obstruction(Perm((0, 1)), [(3, 1), (3, 1)]),
+            Obstruction(Perm((0, 1)), [(2, 3), (2, 3)]),
+            Obstruction(Perm((0, 1)), [(2, 3), (4, 3)]),
+            Obstruction(Perm((0, 1)), [(4, 3), (4, 3)]),
+            Obstruction(Perm((1, 0)), [(1, 0), (1, 0)]),
+            Obstruction(Perm((1, 0)), [(1, 2), (1, 0)]),
+            Obstruction(Perm((1, 0)), [(1, 2), (1, 2)]),
+            Obstruction(Perm((1, 0)), [(3, 1), (3, 1)]),
+            Obstruction(Perm((1, 0)), [(2, 3), (2, 3)]),
+            Obstruction(Perm((1, 0)), [(2, 3), (4, 3)]),
+            Obstruction(Perm((1, 0)), [(4, 3), (4, 3)]),
+            Obstruction(Perm((0, 1, 2)), [(0, 0), (1, 3), (1, 3)]),
+            Obstruction(Perm((0, 2, 3, 1)), [(0, 2), (1, 3), (1, 3), (4, 2)])],
+        requirements=[
+            [Requirement(Perm((0,)), [(3, 1)])],
+            [Requirement(Perm((0,)), [(1, 0)]),
+             Requirement(Perm((0,)), [(1, 2)])],
+            [Requirement(Perm((0,)), [(2, 3)]),
+             Requirement(Perm((0,)), [(4, 3)])],
+            [Requirement(Perm((1, 0)), [(0, 4), (0, 3)]),
+             Requirement(Perm((0, 2, 1)), [(0, 3), (0, 4), (1, 4)])]]))
+    tiling = diverse_tiling.place_point_of_gridded_permutation(
+                                diverse_tiling.requirements[1][0], 0, DIR_WEST)
+    assert tiling == Tiling(
+        obstructions=[
+            Obstruction(Perm((0,)), [(2, 0)]),
+            Obstruction(Perm((0,)), [(2, 2)]),
+            Obstruction(Perm((0, 1)), [(1, 0), (1, 0)]),
+            Obstruction(Perm((0, 1)), [(1, 0), (1, 2)]),
+            Obstruction(Perm((0, 1)), [(1, 2), (1, 2)]),
+            Obstruction(Perm((0, 1)), [(3, 1), (3, 1)]),
+            Obstruction(Perm((0, 1)), [(2, 3), (2, 3)]),
+            Obstruction(Perm((0, 1)), [(2, 3), (4, 3)]),
+            Obstruction(Perm((0, 1)), [(4, 3), (4, 3)]),
+            Obstruction(Perm((1, 0)), [(1, 0), (1, 0)]),
+            Obstruction(Perm((1, 0)), [(1, 2), (1, 0)]),
+            Obstruction(Perm((1, 0)), [(1, 2), (1, 2)]),
+            Obstruction(Perm((1, 0)), [(3, 1), (3, 1)]),
+            Obstruction(Perm((1, 0)), [(2, 3), (2, 3)]),
+            Obstruction(Perm((1, 0)), [(2, 3), (4, 3)]),
+            Obstruction(Perm((1, 0)), [(4, 3), (4, 3)]),
+            Obstruction(Perm((0, 1, 2)), [(0, 0), (1, 3), (1, 3)]),
+            Obstruction(Perm((0, 2, 3, 1)), [(0, 2), (1, 3), (1, 3), (4, 2)])],
+        requirements=[
+            [Requirement(Perm((0,)), [(3, 1)])],
+            [Requirement(Perm((0,)), [(1, 0)]),
+             Requirement(Perm((0,)), [(1, 2)])],
+            [Requirement(Perm((0,)), [(2, 3)]),
+             Requirement(Perm((0,)), [(4, 3)])],
+            [Requirement(Perm((1, 0)), [(0, 4), (0, 3)]),
+             Requirement(Perm((0, 2, 1)), [(0, 3), (0, 4), (1, 4)])]])
+
+    tiling = Tiling(requirements=[[Requirement(Perm((0,)), [(0, 0)])]])
+    assert tiling.place_point_of_gridded_permutation(tiling.requirements[0][0],
+                                                     0, DIR_SOUTH) == Tiling(
+        obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (0, 0)]),
+                      Obstruction(Perm((1, 0)), [(0, 0), (0, 0)])],
+        requirements=[[Requirement(Perm((0,)), [(0, 0)])]])
+
+
+def test_place_point_of_requirement(no_point_tiling):
+    tiling = no_point_tiling.place_point_of_gridded_permutation(
+                            no_point_tiling.requirements[2][0], 1, DIR_WEST)
+    tiling2 = Tiling(
+        obstructions=[
+            Obstruction(Perm((0, 1)), [(0, 1), (1, 3)]),
+            Obstruction(Perm((0, 1)), [(2, 2), (2, 2)]),
+            Obstruction(Perm((1, 0)), [(0, 1), (0, 1)]),
+            Obstruction(Perm((1, 0)), [(0, 3), (0, 1)]),
+            Obstruction(Perm((1, 0)), [(0, 3), (0, 3)]),
+            Obstruction(Perm((1, 0)), [(2, 2), (2, 2)]),
+            Obstruction(Perm((0, 1, 2)), [(0, 0), (1, 0), (1, 0)]),
+            Obstruction(Perm((0, 1, 2)), [(0, 0), (1, 0), (3, 0)]),
+            Obstruction(Perm((0, 1, 2)), [(0, 0), (3, 0), (3, 0)]),
+            Obstruction(Perm((0, 1, 2)), [(1, 0), (1, 0), (4, 0)]),
+            Obstruction(Perm((0, 1, 2)), [(1, 0), (3, 0), (4, 0)]),
+            Obstruction(Perm((0, 1, 2)), [(3, 0), (3, 0), (4, 0)]),
+            Obstruction(Perm((0, 2, 1)), [(0, 1), (1, 1), (1, 1)]),
+            Obstruction(Perm((0, 2, 1)), [(0, 1), (1, 1), (3, 1)]),
+            Obstruction(Perm((0, 2, 1)), [(0, 3), (1, 3), (1, 3)]),
+            Obstruction(Perm((0, 2, 1)), [(0, 3), (1, 3), (3, 3)]),
+            Obstruction(Perm((0, 2, 1)), [(0, 4), (0, 4), (1, 4)]),
+            Obstruction(Perm((0, 2, 1)), [(0, 4), (0, 4), (3, 4)]),
+            Obstruction(Perm((0, 2, 1)), [(0, 4), (1, 4), (1, 4)]),
+            Obstruction(Perm((0, 2, 1)), [(0, 4), (1, 4), (3, 4)]),
+            Obstruction(Perm((0, 2, 1)), [(0, 4), (3, 4), (3, 4)])],
+        requirements=[
+            [Requirement(Perm((0,)), [(2, 2)])],
+            [Requirement(Perm((0, 1)), [(0, 0), (0, 0)]),
+             Requirement(Perm((0, 1)), [(0, 0), (4, 0)])],
+            [Requirement(Perm((0, 1)), [(0, 1), (3, 1)])],
+            [Requirement(Perm((0, 1)), [(1, 1), (4, 1)]),
+             Requirement(Perm((0,)), [(4, 3)]),
+             Requirement(Perm((0,)), [(4, 4)]),
+             Requirement(Perm((0, 1)), [(3, 1), (4, 1)])]]
+    )
+    assert tiling == tiling2

--- a/tests/strategies/test_fusion_strat.py
+++ b/tests/strategies/test_fusion_strat.py
@@ -1,0 +1,105 @@
+import pytest
+
+from comb_spec_searcher import Rule
+from permuta import Perm
+from tilings import Obstruction, Requirement, Tiling
+from tilings.strategies.fusion import component_fusion, fusion
+
+
+@pytest.fixture
+def tiling1():
+    t = Tiling(obstructions=[
+        Obstruction(Perm((1, 0)), ((0, 1), (1, 1))),
+        Obstruction(Perm((1, 0)), ((0, 1), (0, 1))),
+        Obstruction(Perm((1, 0)), ((0, 1), (1, 0))),
+        Obstruction(Perm((1, 0)), ((0, 1), (0, 0))),
+        Obstruction(Perm((1, 0)), ((0, 0), (0, 0))),
+        Obstruction(Perm((1, 0)), ((0, 0), (1, 0))),
+        Obstruction(Perm((1, 0)), ((1, 0), (1, 0))),
+        Obstruction(Perm((1, 0)), ((1, 1), (1, 0))),
+        Obstruction(Perm((1, 0)), ((1, 1), (1, 1)))
+    ])
+    return t
+
+
+@pytest.fixture
+def tiling2():
+    t = Tiling(obstructions=[
+        Obstruction(Perm((0, 1)), ((0, 0), (1, 0))),
+        Obstruction(Perm((0, 2, 1)), ((0, 0), (0, 0), (0, 0))),
+        Obstruction(Perm((0, 2, 1)), ((1, 0), (1, 0), (1, 0))),
+        Obstruction(Perm((0, 2, 1, 3)), ((0, 0), (0, 0), (2, 0), (2, 0))),
+        Obstruction(Perm((0, 2, 1, 3)), ((0, 0), (2, 0), (2, 0), (2, 0))),
+        Obstruction(Perm((0, 2, 1, 3)), ((1, 0), (1, 0), (2, 0), (2, 0))),
+        Obstruction(Perm((0, 2, 1, 3)), ((1, 0), (2, 0), (2, 0), (2, 0))),
+        Obstruction(Perm((0, 2, 1, 3)), ((2, 0), (2, 0), (2, 0), (2, 0)))
+    ])
+    return t
+
+
+def test_component_fusion(tiling1, tiling2):
+    assert len(list(component_fusion(tiling1))) == 0
+    assert len(list(component_fusion(tiling2))) == 1
+
+
+@pytest.fixture
+def small_tiling():
+    t = Tiling(obstructions=[
+        Obstruction(Perm((1, 0)), ((0, 1), (1, 1))),
+        Obstruction(Perm((1, 0)), ((0, 1), (0, 1))),
+        Obstruction(Perm((1, 0)), ((0, 1), (1, 0))),
+        Obstruction(Perm((1, 0)), ((0, 1), (0, 0))),
+        Obstruction(Perm((1, 0)), ((0, 0), (0, 0))),
+        Obstruction(Perm((1, 0)), ((0, 0), (1, 0))),
+        Obstruction(Perm((1, 0)), ((1, 0), (1, 0))),
+        Obstruction(Perm((1, 0)), ((1, 1), (1, 0))),
+        Obstruction(Perm((1, 0)), ((1, 1), (1, 1)))
+    ])
+    return t
+
+
+@pytest.fixture
+def big_tiling():
+    """ The original tiling from Jay's idea """
+    t = Tiling(obstructions=(
+        Obstruction(Perm((0,)), ((0, 1),)),
+        Obstruction(Perm((0,)), ((0, 2),)),
+        Obstruction(Perm((0,)), ((0, 3),)),
+        Obstruction(Perm((0,)), ((1, 2),)),
+        Obstruction(Perm((0,)), ((1, 3),)),
+        Obstruction(Perm((1, 0)), ((0, 0), (0, 0))),
+        Obstruction(Perm((1, 0)), ((0, 0), (1, 0))),
+        Obstruction(Perm((1, 0)), ((0, 0), (2, 0))),
+        Obstruction(Perm((1, 0)), ((1, 0), (1, 0))),
+        Obstruction(Perm((1, 0)), ((1, 0), (2, 0))),
+        Obstruction(Perm((1, 0)), ((1, 1), (1, 0))),
+        Obstruction(Perm((1, 0)), ((1, 1), (1, 1))),
+        Obstruction(Perm((1, 0)), ((1, 1), (2, 0))),
+        Obstruction(Perm((1, 0)), ((1, 1), (2, 1))),
+        Obstruction(Perm((1, 0)), ((2, 0), (2, 0))),
+        Obstruction(Perm((1, 0)), ((2, 1), (2, 0))),
+        Obstruction(Perm((1, 0)), ((2, 1), (2, 1))),
+        Obstruction(Perm((1, 0)), ((2, 2), (2, 0))),
+        Obstruction(Perm((1, 0)), ((2, 2), (2, 1))),
+        Obstruction(Perm((1, 0)), ((2, 2), (2, 2))),
+        Obstruction(Perm((2, 1, 0)), ((2, 3), (2, 3), (2, 0))),
+        Obstruction(Perm((2, 1, 0)), ((2, 3), (2, 3), (2, 1))),
+        Obstruction(Perm((2, 1, 0)), ((2, 3), (2, 3), (2, 2))),
+        Obstruction(Perm((2, 1, 0)), ((2, 3), (2, 3), (2, 3)))
+    ), requirements=())
+    return t
+
+
+def test_fusion(small_tiling, big_tiling):
+    assert len(list(fusion(big_tiling))) == 0
+    small_tiling_rules = list(fusion(small_tiling))
+    assert len(small_tiling_rules) == 2
+    assert all(isinstance(rule, Rule) for rule in small_tiling_rules)
+    assert all(rule.constructor == 'other' for rule in small_tiling_rules)
+    t = Tiling(obstructions=[
+        Obstruction(Perm((0, 1)), ((0, 0), (0, 0))),
+        Obstruction(Perm((0, 1)), ((0, 0), (1, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (1, 0))),
+    ])
+    t_rules = list(fusion(t))
+    assert len(t_rules) == 1

--- a/tests/strategies/test_inferral.py
+++ b/tests/strategies/test_inferral.py
@@ -1,0 +1,217 @@
+import pytest
+
+from permuta import Perm
+from tilings import Obstruction, Requirement, Tiling
+from tilings.strategies.inferral import (obstruction_transitivity,
+                                         row_and_column_separation)
+
+pytest_plugins = [
+    'tests.fixtures.simple_trans'
+]
+
+
+# Obstruction transitivity test
+def test_obstruction_transitivity(simple_trans_row,
+                                  simple_trans_col,
+                                  simple_trans_row_len2,
+                                  simple_trans_row_len3):
+    strat = obstruction_transitivity(simple_trans_row)
+    assert strat.comb_classes[0] == Tiling(
+        obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (1, 0)]),
+                      Obstruction(Perm((0, 1)), [(1, 0), (2, 0)]),
+                      Obstruction(Perm((0, 1)), [(0, 0), (2, 0)])],
+        requirements=[[Requirement(Perm((0,)), [(1, 0)])]])
+
+    strat = obstruction_transitivity(simple_trans_col)
+    assert strat.comb_classes[0] == Tiling(
+        obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (0, 1)]),
+                      Obstruction(Perm((0, 1)), [(0, 1), (0, 2)]),
+                      Obstruction(Perm((0, 1)), [(0, 0), (0, 2)])],
+        requirements=[[Requirement(Perm((0,)), [(0, 1)])]])
+
+    strat = obstruction_transitivity(simple_trans_row_len2)
+    assert strat.comb_classes[0] == Tiling(
+        obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (1, 0)]),
+                      Obstruction(Perm((0, 1)), [(0, 0), (2, 0)]),
+                      Obstruction(Perm((0, 1)), [(0, 0), (3, 0)]),
+                      Obstruction(Perm((0, 1)), [(1, 0), (2, 0)]),
+                      Obstruction(Perm((0, 1)), [(1, 0), (3, 0)]),
+                      Obstruction(Perm((0, 1)), [(2, 0), (3, 0)])],
+        requirements=[[Requirement(Perm((0,)), [(1, 0)])],
+                      [Requirement(Perm((0,)), [(2, 0)])]])
+
+    strat = obstruction_transitivity(simple_trans_row_len3)
+    assert strat.comb_classes[0] == Tiling(
+        obstructions=[Obstruction(Perm((0, 1)), [(0, 0), (1, 0)]),
+                      Obstruction(Perm((0, 1)), [(0, 0), (2, 0)]),
+                      Obstruction(Perm((0, 1)), [(0, 0), (3, 0)]),
+                      Obstruction(Perm((0, 1)), [(0, 0), (4, 0)]),
+                      Obstruction(Perm((0, 1)), [(1, 0), (2, 0)]),
+                      Obstruction(Perm((0, 1)), [(1, 0), (3, 0)]),
+                      Obstruction(Perm((0, 1)), [(1, 0), (4, 0)]),
+                      Obstruction(Perm((0, 1)), [(2, 0), (3, 0)]),
+                      Obstruction(Perm((0, 1)), [(2, 0), (4, 0)]),
+                      Obstruction(Perm((0, 1)), [(3, 0), (4, 0)])],
+        requirements=[[Requirement(Perm((0,)), [(1, 0)])],
+                      [Requirement(Perm((0,)), [(2, 0)])],
+                      [Requirement(Perm((0,)), [(3, 0)])]])
+
+
+# Row column separation test
+@pytest.fixture
+def not_separable_tilings():
+    t1 = Tiling(obstructions=[
+        Obstruction(Perm((0, 1, 2)), ((0, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((1, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((2, 0),)*3),
+        Obstruction(Perm((0, 1)), ((0, 0), (1, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (2, 0)))
+    ])
+    t2 = Tiling(obstructions=[
+        Obstruction(Perm((0, 1, 2)), ((0, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((1, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((2, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((3, 0),)*3),
+        Obstruction(Perm((0, 1)), ((0, 0), (1, 0))),
+        Obstruction(Perm((0, 1)), ((0, 0), (2, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (2, 0))),
+        Obstruction(Perm((0, 1)), ((2, 0), (3, 0))),
+    ])
+    t3 = Tiling(obstructions=[
+        Obstruction(Perm((0, 1, 2)), ((0, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((1, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((2, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((3, 0),)*3),
+        Obstruction(Perm((0, 1)), ((0, 0), (2, 0))),
+        Obstruction(Perm((0, 1)), ((0, 0), (3, 0))),
+        Obstruction(Perm((1, 0)), ((1, 0), (2, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (3, 0))),
+    ])
+    return [t1, t2, t3]
+
+
+@pytest.fixture
+def seperable_tiling1():
+    t1 = Tiling(obstructions=[
+        Obstruction(Perm((0, 1, 2)), ((0, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((1, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((2, 0),)*3),
+        Obstruction(Perm((0, 1)), ((0, 0), (1, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (2, 0))),
+        Obstruction(Perm((0, 1)), ((0, 0), (2, 0))),
+    ])
+    return t1
+
+
+@pytest.fixture
+def seperable_tiling2():
+    t2 = Tiling(obstructions=[
+        Obstruction(Perm((0, 1, 2)), ((0, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((1, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((2, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((3, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((0, 1),)*3),
+        Obstruction(Perm((0, 1, 2)), ((1, 1),)*3),
+        Obstruction(Perm((0, 1, 2)), ((2, 1),)*3),
+        Obstruction(Perm((0,)), ((3, 1),)),
+        Obstruction(Perm((0, 1)), ((0, 0), (0, 1))),
+        Obstruction(Perm((0, 1)), ((0, 0), (1, 0))),
+        Obstruction(Perm((0, 1)), ((0, 0), (2, 0))),
+        Obstruction(Perm((0, 1)), ((0, 0), (3, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (2, 0))),
+        Obstruction(Perm((0, 1)), ((2, 0), (3, 0))),
+        Obstruction(Perm((0, 1)), ((0, 1), (1, 1))),
+        Obstruction(Perm((0, 1)), ((0, 1), (2, 1))),
+        Obstruction(Perm((0, 1)), ((0, 1), (3, 1))),
+        Obstruction(Perm((0, 1)), ((1, 1), (2, 1))),
+        Obstruction(Perm((0, 1)), ((2, 1), (3, 1))),
+    ])
+    return t2
+
+
+@pytest.fixture
+def seperable_tiling3():
+    t3 = Tiling(obstructions=[
+        Obstruction(Perm((0, 1, 2)), ((0, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((1, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((2, 0),)*3),
+        Obstruction(Perm((0, 1, 2)), ((3, 0),)*3),
+        Obstruction(Perm((0, 1)), ((0, 0), (2, 0))),
+        Obstruction(Perm((0, 1)), ((0, 0), (3, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (2, 0))),
+        Obstruction(Perm((0, 1)), ((1, 0), (3, 0))),
+    ])
+    return t3
+
+
+def test_row_col_seperation(not_separable_tilings, seperable_tiling1,
+                            seperable_tiling2, seperable_tiling3):
+    t = Tiling(obstructions=[
+        Obstruction(Perm((0, 1)), ((0, 0),)*2),
+        Obstruction(Perm((0, 1)), ((1, 0),)*2),
+        Obstruction(Perm((0, 1)), ((0, 0), (1, 0))),
+    ])
+    rcs = row_and_column_separation(t)
+    assert rcs.comb_classes[0] == Tiling(obstructions=[
+        Obstruction(Perm((0, 1)), ((0, 1),)*2),
+        Obstruction(Perm((0, 1)), ((1, 0),)*2),
+    ])
+
+    for t in not_separable_tilings:
+        assert row_and_column_separation(t) is None
+    t1_sep = Tiling(obstructions=(
+        Obstruction(Perm((0,)), ((0, 0),)),
+        Obstruction(Perm((0,)), ((0, 1),)),
+        Obstruction(Perm((0,)), ((1, 0),)),
+        Obstruction(Perm((0,)), ((1, 2),)),
+        Obstruction(Perm((0,)), ((2, 1),)),
+        Obstruction(Perm((0,)), ((2, 2),)),
+        Obstruction(Perm((0, 1, 2)), ((0, 2), (0, 2), (0, 2))),
+        Obstruction(Perm((0, 1, 2)), ((1, 1), (1, 1), (1, 1))),
+        Obstruction(Perm((0, 1, 2)), ((2, 0), (2, 0), (2, 0)))
+    ), requirements=())
+    t2_sep = Tiling(obstructions=(
+        Obstruction(Perm((0,)), ((0, 0),)),
+        Obstruction(Perm((0,)), ((0, 1),)),
+        Obstruction(Perm((0,)), ((0, 2),)),
+        Obstruction(Perm((0,)), ((0, 3),)),
+        Obstruction(Perm((0,)), ((1, 0),)),
+        Obstruction(Perm((0,)), ((1, 2),)),
+        Obstruction(Perm((0,)), ((1, 3),)),
+        Obstruction(Perm((0,)), ((1, 4),)),
+        Obstruction(Perm((0,)), ((2, 1),)),
+        Obstruction(Perm((0,)), ((2, 2),)),
+        Obstruction(Perm((0,)), ((2, 4),)),
+        Obstruction(Perm((0,)), ((3, 1),)),
+        Obstruction(Perm((0,)), ((3, 3),)),
+        Obstruction(Perm((0,)), ((3, 4),)),
+        Obstruction(Perm((0,)), ((4, 1),)),
+        Obstruction(Perm((0,)), ((4, 2),)),
+        Obstruction(Perm((0,)), ((4, 3),)),
+        Obstruction(Perm((0,)), ((4, 4),)),
+        Obstruction(Perm((0, 1)), ((2, 0), (3, 0))),
+        Obstruction(Perm((0, 1)), ((3, 0), (4, 0))),
+        Obstruction(Perm((0, 1, 2)), ((0, 4), (0, 4), (0, 4))),
+        Obstruction(Perm((0, 1, 2)), ((1, 1), (1, 1), (1, 1))),
+        Obstruction(Perm((0, 1, 2)), ((2, 0), (2, 0), (2, 0))),
+        Obstruction(Perm((0, 1, 2)), ((2, 3), (2, 3), (2, 3))),
+        Obstruction(Perm((0, 1, 2)), ((3, 0), (3, 0), (3, 0))),
+        Obstruction(Perm((0, 1, 2)), ((3, 2), (3, 2), (3, 2))),
+        Obstruction(Perm((0, 1, 2)), ((4, 0), (4, 0), (4, 0)))
+    ), requirements=())
+    t3_sep = Tiling(obstructions=(
+        Obstruction(Perm((0,)), ((0, 0),)),
+        Obstruction(Perm((0,)), ((1, 0),)),
+        Obstruction(Perm((0,)), ((2, 1),)),
+        Obstruction(Perm((0,)), ((3, 1),)),
+        Obstruction(Perm((0, 1, 2)), ((0, 1), (0, 1), (0, 1))),
+        Obstruction(Perm((0, 1, 2)), ((1, 1), (1, 1), (1, 1))),
+        Obstruction(Perm((0, 1, 2)), ((2, 0), (2, 0), (2, 0))),
+        Obstruction(Perm((0, 1, 2)), ((3, 0), (3, 0), (3, 0)))
+    ), requirements=())
+    assert (row_and_column_separation(seperable_tiling1).comb_classes[0] ==
+            t1_sep)
+    assert (row_and_column_separation(seperable_tiling2).comb_classes[0] ==
+            t2_sep)
+    assert (row_and_column_separation(seperable_tiling3).comb_classes[0] ==
+            t3_sep)

--- a/tilings/algorithms/__init__.py
+++ b/tilings/algorithms/__init__.py
@@ -10,6 +10,7 @@ from .obstruction_inferral import (AllObstructionInferral, EmptyCellInferral,
 from .obstruction_transitivity import ObstructionTransitivity
 from .requirement_insertion import (CellInsertion, ColInsertion,
                                     CrossingInsertion, FactorInsertion,
+                                    RequirementCorroboration,
                                     RequirementExtension, RowInsertion)
 from .requirement_placement import RequirementPlacement
 from .row_col_separation import RowColSeparation

--- a/tilings/algorithms/__init__.py
+++ b/tilings/algorithms/__init__.py
@@ -8,5 +8,8 @@ from .fusion import ComponentFusion, Fusion
 from .obstruction_inferral import (AllObstructionInferral, EmptyCellInferral,
                                    SubobstructionInferral)
 from .obstruction_transitivity import ObstructionTransitivity
+from .requirement_insertion import (CellInsertion, ColInsertion,
+                                    CrossingInsertion, FactorInsertion,
+                                    RequirementExtension, RowInsertion)
 from .requirement_placement import RequirementPlacement
 from .row_col_separation import RowColSeparation

--- a/tilings/algorithms/requirement_insertion.py
+++ b/tilings/algorithms/requirement_insertion.py
@@ -198,3 +198,14 @@ class FactorInsertion(RequirementInsertion):
         proper_facts = chain.from_iterable(f for f in gp_facts if len(f) > 1)
         for f in proper_facts:
             yield (Requirement(f.patt, f.pos),)
+
+
+class RequirementCorroboration(RequirementInsertion):
+    """
+    Insert one requirement from a requirement list.
+    """
+    def req_lists_to_insert(self) -> Iterable[ListRequirement]:
+        to_insert = chain.from_iterable(
+            reqs for reqs in self.tiling.requirements if len(reqs) > 1)
+        for req in to_insert:
+            yield (req,)

--- a/tilings/strategies/batch.py
+++ b/tilings/strategies/batch.py
@@ -123,6 +123,17 @@ def col_placements(tiling, **kwargs):
     yield from RequirementPlacement(tiling).all_col_placement_rules()
 
 
+def all_placements(tiling, **kwargs):
+    req_placements = (RequirementPlacement(tiling),
+                      RequirementPlacement(tiling, own_row=False),
+                      RequirementPlacement(tiling, own_col=False))
+    for req_placement in req_placements:
+        yield from req_placement.all_point_placement_rules()
+        yield from req_placement.all_requirement_placement_rules()
+        yield from req_placement.all_col_placement_rules()
+        yield from req_placement.all_row_placement_rules()
+
+
 def row_and_col_placements(tiling, **kwargs):
     req_placements = RequirementPlacement(tiling)
     yield from req_placements.all_row_placement_rules()

--- a/tilings/strategies/batch.py
+++ b/tilings/strategies/batch.py
@@ -84,7 +84,7 @@ def all_requirement_insertions(tiling: Tiling, maxreqlen: int = 1,
                                  extra_basis).rules(ignore_parent)
 
 
-def all_factor_insertions(tiling: Tiling, ignore_parent: bool = False,
+def all_factor_insertions(tiling: Tiling, ignore_parent: bool = True,
                           **kwargs) -> Iterable[Rule]:
     """
     Insert all proper factor of the requirement or obstructions on the tiling.

--- a/tilings/strategies/batch.py
+++ b/tilings/strategies/batch.py
@@ -149,15 +149,3 @@ def partial_row_and_col_placements(tiling, **kwargs):
     for req_placement in req_placements:
         yield from req_placement.all_row_placement_rules()
         yield from req_placement.all_col_placement_rules()
-
-
-# TODO: Clarify what is this function doing
-def requirement_list_placement(tiling, **kwargs):
-    """Places all requirements on the tiling in every direction."""
-    req_placement = RequirementPlacement(tiling)
-    directions = (DIR_EAST, DIR_NORTH, DIR_SOUTH, DIR_WEST)
-    for req, direction in product(tiling.requirements, directions):
-        yield BatchRule(req_placement.place_point_of_req_list(req, direction),
-                        "Inserting {} point of requirement list ({})".format(
-                            req_placement._direction_string(direction),
-                            ", ".join(str(r) for r in req)))

--- a/tilings/strategies/batch.py
+++ b/tilings/strategies/batch.py
@@ -1,0 +1,163 @@
+from itertools import product
+from typing import Iterable, List, Optional
+
+from comb_spec_searcher import BatchRule, Rule
+from permuta import Perm
+from permuta.misc import DIR_EAST, DIR_NORTH, DIR_SOUTH, DIR_WEST
+from tilings import Tiling
+from tilings.algorithms import (CellInsertion, ColInsertion, CrossingInsertion,
+                                FactorInsertion, RequirementCorroboration,
+                                RequirementExtension, RequirementPlacement,
+                                RowInsertion)
+
+
+# -------------------------------------
+#   Requirement Insertion             |
+# -------------------------------------
+def all_cell_insertions(tiling: Tiling, maxreqlen: int = 1, extra_basis:
+                        Optional[List[Perm]] = None,
+                        ignore_parent: bool = False,
+                        **kwargs) -> Iterable[Rule]:
+    """
+    The cell insertion strategy.
+
+    The cell insertion strategy is a batch strategy that considers each active
+    cells, excluding positive cells. For each of these cells, the strategy
+    considers all patterns (up to some maximum length given by maxreqlen, and
+    some maximum number given by maxreqnum) and returns two tilings; one which
+    requires the pattern in the cell and one where the pattern is obstructed.
+    """
+    yield from CellInsertion(tiling, maxreqlen,
+                             extra_basis).rules(ignore_parent)
+
+
+def root_requirement_insertion(tiling, **kwargs) -> Iterable[Rule]:
+    """
+    The cell insertion strategy performed only on 1 by 1 tilings.
+    """
+    if tiling.dimensions != (1, 1) or tiling.requirements:
+        return
+    yield from all_cell_insertions(tiling, **kwargs)
+
+
+def all_point_insertions(tiling, **kwargs) -> Iterable[Rule]:
+    """
+    The cell insertion strategy using only points.
+    """
+    yield from all_cell_insertions(tiling, maxreqlen=1, **kwargs)
+
+
+def all_requirement_extensions(tiling: Tiling, maxreqlen: int = 2,
+                               extra_basis: Optional[List[Perm]] = None,
+                               ignore_parent: bool = False,
+                               **kwargs) -> Iterable[Rule]:
+    """
+    Insert longer requirements in to cells which contain a requirement
+    """
+    yield from RequirementExtension(tiling, maxreqlen,
+                                    extra_basis).rules(ignore_parent)
+
+
+def all_row_insertions(tiling: Tiling, ignore_parent: bool = False,
+                       **kwargs) -> Iterable[Rule]:
+    """Insert a list requirement into every possibly empty row."""
+    yield from RowInsertion(tiling).rules(ignore_parent)
+
+
+def all_col_insertions(tiling, ignore_parent: bool = False,
+                       **kwargs) -> Iterable[Rule]:
+    """Insert a list requirement into every possibly empty column."""
+    yield from ColInsertion(tiling).rules(ignore_parent)
+
+
+def all_requirement_insertions(tiling: Tiling, maxreqlen: int = 1,
+                               extra_basis: Optional[List[Perm]] = None,
+                               ignore_parent: bool = False,
+                               **kwargs) -> Iterable[Rule]:
+    """
+    Insert all possible requirements the obstruction allows if the tiling does
+    not have requirements.
+    """
+    if tiling.requirements:
+        return
+    yield from CrossingInsertion(tiling, maxreqlen,
+                                 extra_basis).rules(ignore_parent)
+
+
+def all_factor_insertions(tiling: Tiling, ignore_parent: bool = False,
+                          **kwargs) -> Iterable[Rule]:
+    """
+    Insert all proper factor of the requirement or obstructions on the tiling.
+    """
+    yield from FactorInsertion(tiling).rules(ignore_parent)
+
+
+def requirement_corroboration(tiling: Tiling, ignore_parent: bool = True,
+                              **kwargs) -> Iterable[Rule]:
+    """
+    The requirement corroboration strategy.
+
+    The requirement corroboration strategy is a batch strategy that considers
+    each requirement of each requirement list. For each of these requirements,
+    the strategy returns two tilings; one where the requirement has been turned
+    into an obstruction and another where the requirement has been singled out
+    and a new requirement list added with only the requirement. This new
+    requirement list contains only the singled out requirement.
+
+    This implements the notion of partitioning the set of gridded permutations
+    into those that satisfy this requirement and those that avoid it. Those
+    that avoid the requirement, must therefore satisfy another requirement from
+    the same list and hence the requirement list must be of length at least 2.
+    """
+    yield from RequirementCorroboration(tiling).rules(ignore_parent)
+
+
+# -------------------------------------
+#   Row and column placement          |
+# -------------------------------------
+def row_placements(tiling, **kwargs):
+    yield from RequirementPlacement(tiling).all_row_placement_rules()
+
+
+def col_placements(tiling, **kwargs):
+    yield from RequirementPlacement(tiling).all_col_placement_rules()
+
+
+def row_and_col_placements(tiling, **kwargs):
+    req_placements = RequirementPlacement(tiling)
+    yield from req_placements.all_row_placement_rules()
+    yield from req_placements.all_col_placement_rules()
+
+
+def partial_row_placements(tiling, **kwargs):
+    req_placements = (RequirementPlacement(tiling, own_row=False),
+                      RequirementPlacement(tiling, own_col=False))
+    for req_placement in req_placements:
+        yield from req_placement.all_row_placement_rules()
+
+
+def partial_col_placements(tiling, **kwargs):
+    req_placements = (RequirementPlacement(tiling, own_row=False),
+                      RequirementPlacement(tiling, own_col=False))
+    for req_placement in req_placements:
+        yield from req_placement.all_col_placement_rules()
+
+
+def partial_row_and_col_placements(tiling, **kwargs):
+    req_placements = (RequirementPlacement(tiling, own_row=False),
+                      RequirementPlacement(tiling, own_col=False))
+    for req_placement in req_placements:
+        yield from req_placement.all_row_placement_rules()
+        yield from req_placement.all_col_placement_rules()
+
+
+# TODO: Clarify what is this function doing
+def requirement_list_placement(tiling, **kwargs):
+    """Places all requirements on the tiling in every direction."""
+    req_placement = RequirementPlacement(tiling)
+    directions = (DIR_EAST, DIR_NORTH, DIR_SOUTH, DIR_WEST)
+    for req, direction in product(tiling.requirements, directions):
+        yield BatchRule(req_placement.place_point_of_req_list(req, direction),
+                        "Inserting {} point of requirement list ({})".format(
+                            req_placement._direction_string(direction),
+                            ", ".join(str(r) for r in req)))

--- a/tilings/strategies/decomposition.py
+++ b/tilings/strategies/decomposition.py
@@ -1,0 +1,41 @@
+from tilings.algorithms import (Factor, FactorWithInterleaving,
+                                FactorWithMonotoneInterleaving)
+
+
+def general_factor(tiling, factor_class, union=False, **kwargs):
+    """
+    Iterator of factor strategy.
+    """
+    assert factor_class in [Factor, FactorWithMonotoneInterleaving,
+                            FactorWithInterleaving]
+    workable = kwargs.get('workable', True)
+    factor_algo = factor_class(tiling)
+    if factor_algo.factorable():
+        yield factor_algo.rule(workable=workable)
+        if union:
+            yield from factor_algo.all_union_rules()
+
+
+def factor(tiling, **kwargs):
+    return general_factor(tiling, Factor, **kwargs)
+
+
+def factor_with_monotone_interleaving(tiling, **kwargs):
+    return general_factor(tiling, FactorWithMonotoneInterleaving, **kwargs)
+
+
+def factor_with_interleaving(tiling, **kwargs):
+    return general_factor(tiling, FactorWithInterleaving, **kwargs)
+
+
+def unions_of_factor(tiling, **kwargs):
+    return general_factor(tiling, Factor, union=True, **kwargs)
+
+
+def unions_of_factor_with_monotone_interleaving(tiling, **kwargs):
+    return general_factor(tiling, FactorWithMonotoneInterleaving, union=True,
+                          **kwargs)
+
+
+def unions_of_factor_with_interleaving(tiling, **kwargs):
+    return general_factor(tiling, FactorWithInterleaving, union=True, **kwargs)

--- a/tilings/strategies/equivalence.py
+++ b/tilings/strategies/equivalence.py
@@ -1,6 +1,4 @@
-from itertools import chain
-
-from tilings.algorithms import ComponentFusion, Fusion, RequirementPlacement
+from tilings.algorithms import RequirementPlacement
 
 
 # -------------------------------------
@@ -68,37 +66,3 @@ def partial_point_placement(tiling, **kwargs):
     point has been placed with a force.
     """
     yield from partial_requirement_placement(tiling, point_only=True)
-
-
-# -------------------------------------
-#   Fusion strategies                 |
-# -------------------------------------
-def general_fusion_iterator(tiling, fusion_class):
-    """
-    Generator over rules found by fusing rows or columns of `tiling` using
-    the fusion defined by `fusion_class`.
-    """
-    assert issubclass(fusion_class, Fusion)
-    ncol = tiling.dimensions[0]
-    nrow = tiling.dimensions[1]
-    possible_fusion = chain(
-        (fusion_class(tiling, row_idx=r) for r in range(nrow-1)),
-        (fusion_class(tiling, col_idx=c) for c in range(ncol-1))
-    )
-    return (fusion.rule() for fusion in possible_fusion if fusion.fusable())
-
-
-def fusion(tiling, **kwargs):
-    """Generator over rules found by fusing rows or columns of `tiling`."""
-    return general_fusion_iterator(tiling, fusion_class=Fusion)
-
-
-def component_fusion(tiling, **kwargs):
-    """
-    Yield rules found by fusing rows and columns of a tiling, where the
-    unfused tiling obtained by drawing a line through certain heights/indices
-    of the row/column.
-    """
-    if tiling.requirements:
-        return
-    yield from general_fusion_iterator(tiling, ComponentFusion)

--- a/tilings/strategies/equivalence.py
+++ b/tilings/strategies/equivalence.py
@@ -1,0 +1,104 @@
+from itertools import chain
+
+from tilings.algorithms import ComponentFusion, Fusion, RequirementPlacement
+
+
+# -------------------------------------
+#   Placement                         |
+# -------------------------------------
+def requirement_placement(tiling, **kwargs):
+    """
+    Strategy that places a single forced point of a requirement.
+
+    The requirement_placement strategy considers every requirement list of
+    length exactly 1. For each of these requirements, it considers all the
+    points of the requirement. The strategy then returns all tilings where the
+    point has been placed with a force.
+    """
+    yield from RequirementPlacement(tiling).all_requirement_placement_rules()
+
+
+def point_placement(tiling, **kwargs):
+    """
+    Strategy that place a single forced point of a point requirement.
+
+    The point placement strategy considers all point requirements in their own
+    requirement lists. For each of them, it returns a new tiling where the
+    point has been placed with a force.
+    """
+    yield from RequirementPlacement(tiling).all_point_placement_rules()
+
+
+def all_placements(tiling, **kwargs):
+    req_placements = (RequirementPlacement(tiling),
+                      RequirementPlacement(tiling, own_row=False),
+                      RequirementPlacement(tiling, own_col=False))
+    for req_placement in req_placements:
+        yield from req_placement.all_point_placement_rules()
+        yield from req_placement.all_requirement_placement_rules()
+        yield from req_placement.all_col_placement_rules()
+        yield from req_placement.all_row_placement_rules()
+
+
+# -------------------------------------
+#   Partial Placement                 |
+# -------------------------------------
+def partial_requirement_placement(tiling, **kwargs):
+    """
+    Strategy that places a single forced point of a requirement onto it own row
+    or onto its own column.
+
+    The partial_requirement_placement strategy considers every requirement list
+    of length exactly 1. For each of these requirements, it considers all the
+    points of the requirement. The strategy then returns all tilings where the
+    point has been partially placed with a force.
+    """
+    req_placements = (RequirementPlacement(tiling, own_row=False),
+                      RequirementPlacement(tiling, own_col=False))
+    for req_placement in req_placements:
+        yield from req_placement.all_requirement_placement_rules()
+
+
+def partial_point_placement(tiling, **kwargs):
+    """
+    Strategy that place a single forced point of a point requirement.
+
+    The point placement strategy considers all point requirements in their own
+    requirement lists. For each of them, it returns a new tiling where the
+    point has been placed with a force.
+    """
+    yield from partial_requirement_placement(tiling, point_only=True)
+
+
+# -------------------------------------
+#   Fusion strategies                 |
+# -------------------------------------
+def general_fusion_iterator(tiling, fusion_class):
+    """
+    Generator over rules found by fusing rows or columns of `tiling` using
+    the fusion defined by `fusion_class`.
+    """
+    assert issubclass(fusion_class, Fusion)
+    ncol = tiling.dimensions[0]
+    nrow = tiling.dimensions[1]
+    possible_fusion = chain(
+        (fusion_class(tiling, row_idx=r) for r in range(nrow-1)),
+        (fusion_class(tiling, col_idx=c) for c in range(ncol-1))
+    )
+    return (fusion.rule() for fusion in possible_fusion if fusion.fusable())
+
+
+def fusion(tiling, **kwargs):
+    """Generator over rules found by fusing rows or columns of `tiling`."""
+    return general_fusion_iterator(tiling, fusion_class=Fusion)
+
+
+def component_fusion(tiling, **kwargs):
+    """
+    Yield rules found by fusing rows and columns of a tiling, where the
+    unfused tiling obtained by drawing a line through certain heights/indices
+    of the row/column.
+    """
+    if tiling.requirements:
+        return
+    yield from general_fusion_iterator(tiling, ComponentFusion)

--- a/tilings/strategies/equivalence.py
+++ b/tilings/strategies/equivalence.py
@@ -27,17 +27,6 @@ def point_placement(tiling, **kwargs):
     yield from RequirementPlacement(tiling).all_point_placement_rules()
 
 
-def all_placements(tiling, **kwargs):
-    req_placements = (RequirementPlacement(tiling),
-                      RequirementPlacement(tiling, own_row=False),
-                      RequirementPlacement(tiling, own_col=False))
-    for req_placement in req_placements:
-        yield from req_placement.all_point_placement_rules()
-        yield from req_placement.all_requirement_placement_rules()
-        yield from req_placement.all_col_placement_rules()
-        yield from req_placement.all_row_placement_rules()
-
-
 # -------------------------------------
 #   Partial Placement                 |
 # -------------------------------------

--- a/tilings/strategies/fusion.py
+++ b/tilings/strategies/fusion.py
@@ -1,0 +1,34 @@
+from itertools import chain
+
+from tilings.algorithms import ComponentFusion, Fusion
+
+
+def general_fusion_iterator(tiling, fusion_class):
+    """
+    Generator over rules found by fusing rows or columns of `tiling` using
+    the fusion defined by `fusion_class`.
+    """
+    assert issubclass(fusion_class, Fusion)
+    ncol = tiling.dimensions[0]
+    nrow = tiling.dimensions[1]
+    possible_fusion = chain(
+        (fusion_class(tiling, row_idx=r) for r in range(nrow-1)),
+        (fusion_class(tiling, col_idx=c) for c in range(ncol-1))
+    )
+    return (fusion.rule() for fusion in possible_fusion if fusion.fusable())
+
+
+def fusion(tiling, **kwargs):
+    """Generator over rules found by fusing rows or columns of `tiling`."""
+    return general_fusion_iterator(tiling, fusion_class=Fusion)
+
+
+def component_fusion(tiling, **kwargs):
+    """
+    Yield rules found by fusing rows and columns of a tiling, where the
+    unfused tiling obtained by drawing a line through certain heights/indices
+    of the row/column.
+    """
+    if tiling.requirements:
+        return
+    yield from general_fusion_iterator(tiling, ComponentFusion)

--- a/tilings/strategies/inferral.py
+++ b/tilings/strategies/inferral.py
@@ -1,0 +1,44 @@
+from tilings.algorithms import (EmptyCellInferral, ObstructionTransitivity,
+                                RowColSeparation, SubobstructionInferral)
+
+
+def obstruction_transitivity(tiling, **kwargs):
+    """
+    The obstruction transitivity strategy.
+
+    The obstruction transitivity considers all length 2 obstructions with both
+    points in the same row or some column. By considering these length 2
+    obstructions in similar manner as the row and column separation, as
+    inequality relations. When the obstructions use a positive cell,
+    transitivity applies, i.e. if a < b < c and b is positive, then a < c.
+    """
+    obs_trans = ObstructionTransitivity(tiling)
+    return obs_trans.rule()
+
+
+def row_and_column_separation(tiling, **kwargs):
+    """
+    An inferral function that tries to separate cells in rows and columns.
+    """
+    rcs = RowColSeparation(tiling)
+    return rcs.rule()
+
+
+def empty_cell_inferral(tiling, **kwargs):
+    """
+    The empty cell inferral strategy.
+
+    The strategy considers each active but non-positive cell and inserts a
+    point requirement. If the resulting tiling is empty, then a point
+    obstruction can be added into the cell, i.e. the cell is empty."""
+    eci = EmptyCellInferral(tiling)
+    return eci.rule()
+
+
+def subobstruction_inferral(tiling, **kwargs):
+    """
+    Return tiling created by adding all subobstructions which can be
+    added.
+    """
+    soi = SubobstructionInferral(tiling)
+    return soi.rule()

--- a/tilings/strategies/verification.py
+++ b/tilings/strategies/verification.py
@@ -1,0 +1,51 @@
+from tilings.algorithms.enumeration import (BasicEnumeration,
+                                            DatabaseEnumeration,
+                                            ElementaryEnumeration,
+                                            LocalEnumeration,
+                                            LocallyFactorableEnumeration,
+                                            OneByOneEnumeration)
+
+
+def verify_basic(tiling, **kwargs):
+    """
+    Verify the most basics tilings.
+    """
+    return BasicEnumeration(tiling).verification_rule()
+
+
+def verify_one_by_one(tiling, basis, **kwargs):
+    """Return a verification if one-by-one verified."""
+    return OneByOneEnumeration(tiling, basis).verification_rule()
+
+
+def verify_database(tiling, **kwargs):
+    """Verify a tiling that is in the database"""
+    return DatabaseEnumeration(tiling).verification_rule()
+
+
+def verify_locally_factorable(tiling, **kwargs):
+    """
+    The locally factorable verified strategy.
+
+    A tiling is globally verified if every requirement and obstruction is
+    non-interleaving.
+    """
+    return LocallyFactorableEnumeration(tiling).verification_rule()
+
+
+def verify_elementary(tiling, **kwargs):
+    """
+    A tiling is elementary verified if it is locally factorable
+    and has no interleaving cells.
+    """
+    return ElementaryEnumeration(tiling).verification_rule()
+
+
+def verify_local(tiling, no_reqs=False, **kwargs):
+    """
+    The local verified strategy.
+
+    A tiling is local verified if every obstruction and every requirement is
+    localized and the tiling is not 1x1.
+    """
+    return LocalEnumeration(tiling, no_reqs).verification_rule()


### PR DESCRIPTION
Closes #83 

- [x] Verification strategies
- [x] Inferral strategies
- [x] Decomposition strategies
- [x] Equivalence strategies
- [x] Batch strategies
- [ ] Move the tests for the strategies' function from `tilescope` to `tilings`