### PR TITLE
fix partial row and column placements

### DIFF
--- a/tests/algorithms/test_requirement_placements.py
+++ b/tests/algorithms/test_requirement_placements.py
@@ -271,9 +271,27 @@ def test_all_point_placement_rules(placement1, placement2, placement2owncol,
         assert rule.workable == [True]
         assert rule.constructor == 'equiv'
         assert rule.possibly_empty == [False]
+    for rule in placement2ownrow.all_point_placement_rules():
+        assert isinstance(rule, Rule)
+        assert len(rule.comb_classes) == 1
+        assert re.match(r'Placing partially (topmost|bottommost) '
+                        r'point in cell \(\d+, \d+\)\.', rule.formal_step)
+        assert not rule.ignore_parent
+        assert rule.workable == [True]
+        assert rule.constructor == 'equiv'
+        assert rule.possibly_empty == [False]
+    for rule in placement2owncol.all_point_placement_rules():
+        assert isinstance(rule, Rule)
+        assert len(rule.comb_classes) == 1
+        assert re.match(r'Placing partially (rightmost|leftmost) '
+                        r'point in cell \(\d+, \d+\)\.', rule.formal_step)
+        assert not rule.ignore_parent
+        assert rule.workable == [True]
+        assert rule.constructor == 'equiv'
+        assert rule.possibly_empty == [False]
 
 
-def test_all_requirement_placement_rules(placement1):
+def test_all_requirement_placement_rules():
     t = Tiling(obstructions=[Obstruction(Perm((1, 0)), ((0, 0),)*2)],
                requirements=[[Requirement(Perm((0, 1)), ((0, 0),)*2)]])
     placement = RequirementPlacement(t)
@@ -309,6 +327,30 @@ def test_all_requirement_placement_rules(placement1):
         [Requirement(Perm((0,)), ((2, 2),))],
     ]) in comb_classes
 
+
+def test_all_requirement_placement_rules_partial(placement2owncol,
+                                                 placement2ownrow):
+    print(placement2owncol._tiling)
+    for rule in placement2owncol.all_requirement_placement_rules():
+        assert isinstance(rule, Rule)
+        assert len(rule.comb_classes) == 1
+        assert isinstance(rule.formal_step, str) and len(rule.formal_step) > 0
+        assert re.match(r'Placing partially the (leftmost|rightmost) '
+                        r'point of \(\d+, \d+\) in \d+: (\(\d+, \d+\), )*'
+                        r'\(\d+, \d+\)\.', rule.formal_step)
+        assert rule.workable == [True]
+        assert rule.constructor == 'equiv'
+        assert rule.possibly_empty == [False]
+    for rule in placement2ownrow.all_requirement_placement_rules():
+        assert isinstance(rule, Rule)
+        assert len(rule.comb_classes) == 1
+        assert isinstance(rule.formal_step, str) and len(rule.formal_step) > 0
+        assert re.match(r'Placing partially the (topmost|bottommost) '
+                        r'point of \(\d+, \d+\) in \d+: (\(\d+, \d+\), )*'
+                        r'\(\d+, \d+\)\.', rule.formal_step)
+        assert rule.workable == [True]
+        assert rule.constructor == 'equiv'
+        assert rule.possibly_empty == [False]
 
 # ------------------------------------------------------------
 #       Tests for RequirementPlacement Class

--- a/tests/algorithms/test_requirement_placements.py
+++ b/tests/algorithms/test_requirement_placements.py
@@ -197,6 +197,27 @@ def test_all_col_placement_rules(placement1):
             [2, 2, 2, 2, 2, 2, 3, 3])
 
 
+def test_all_col_placement_rules_partial(placement1owncol, placement1ownrow):
+    print(placement1owncol._tiling)
+    rules = list(placement1owncol.all_col_placement_rules())
+    assert len(rules) == 8
+    for rule in rules:
+        assert isinstance(rule, Rule)
+        assert len(rule.comb_classes) > 1
+        assert re.match(r'Placing partially ((leftmost)|(rightmost)) points '
+                        r'in column \d+\.', rule.formal_step)
+        assert not rule.ignore_parent
+        assert all(rule.workable)
+        assert rule.constructor == 'disjoint'
+        assert all(rule.possibly_empty)
+    assert (sorted(len(rule.comb_classes) for rule in rules) ==
+            [2, 2, 2, 2, 2, 2, 3, 3])
+
+    # Nothing to do if not placing on own col
+    rules = list(placement1ownrow.all_col_placement_rules())
+    assert len(rules) == 0
+
+
 def test_all_row_placement_rules(placement1):
     rules = list(placement1.all_row_placement_rules())
     assert len(rules) == 6
@@ -211,6 +232,27 @@ def test_all_row_placement_rules(placement1):
         assert all(rule.possibly_empty)
     assert (sorted(len(rule.comb_classes) for rule in rules) ==
             [2, 2, 3, 3, 3, 3])
+
+
+def test_all_row_placement_rules_partial(placement1owncol, placement1ownrow):
+    print(placement1owncol._tiling)
+    rules = list(placement1ownrow.all_row_placement_rules())
+    assert len(rules) == 6
+    for rule in rules:
+        assert isinstance(rule, Rule)
+        assert len(rule.comb_classes) > 1
+        assert re.match(r'Placing partially ((topmost)|(bottommost)) points '
+                        r'in row \d+\.', rule.formal_step)
+        assert not rule.ignore_parent
+        assert all(rule.workable)
+        assert rule.constructor == 'disjoint'
+        assert all(rule.possibly_empty)
+    assert (sorted(len(rule.comb_classes) for rule in rules) ==
+            [2, 2, 3, 3, 3, 3])
+
+    # Nothing to do if only not placing on own row
+    rules = list(placement1owncol.all_row_placement_rules())
+    assert len(rules) == 0
 
 
 def test_all_point_placement_rules(placement1, placement2, placement2owncol,

--- a/tilings/algorithms/requirement_placement.py
+++ b/tilings/algorithms/requirement_placement.py
@@ -360,13 +360,21 @@ class RequirementPlacement():
         return s
 
     def _point_placement_formal_step(self, cell, direction):
-        return "Placing {} point in cell {}.".format(
-                                       self._direction_string(direction), cell)
+        dir_str = self._direction_string(direction)
+        s = 'Placing '
+        if not (self._own_col and self._own_row):
+            s += 'partially '
+        s += '{} point in cell {}.'.format(dir_str, cell)
+        return s
 
     def _pattern_placement_formal_step(self, idx, gp, direction):
-        return "Placing the {} point of ({}, {}) in {}.".format(
-                                            self._direction_string(direction),
-                                            idx, gp.patt[idx], str(gp))
+        dir_str = self._direction_string(direction)
+        s = 'Placing '
+        if not (self._own_col and self._own_row):
+            s += 'partially '
+        s += 'the {} point of ({}, {}) in {}.'.format(
+            dir_str, idx, gp.patt[idx], gp)
+        return s
 
     @staticmethod
     def _direction_string(direction):

--- a/tilings/algorithms/requirement_placement.py
+++ b/tilings/algorithms/requirement_placement.py
@@ -290,7 +290,7 @@ class RequirementPlacement():
         """
         Yield all possible rules coming from placing points in a column.
         """
-        if not self._own_row:
+        if not self._own_col:
             return
         for index in range(self._tiling.dimensions[0]):
             for direction in self.directions:
@@ -344,12 +344,20 @@ class RequirementPlacement():
                 yield EquivalenceRule(formal_step, placed_tiling)
 
     def _col_placement_formal_step(self, idx, direction):
-        return "Placing {} points in column {}.".format(
-                                        self._direction_string(direction), idx)
+        dir_str = self._direction_string(direction)
+        s = 'Placing '
+        if not (self._own_col and self._own_row):
+            s += 'partially '
+        s += '{} points in column {}.'.format(dir_str, idx)
+        return s
 
     def _row_placement_formal_step(self, idx, direction):
-        return "Placing {} points in row {}.".format(
-                                        self._direction_string(direction), idx)
+        dir_str = self._direction_string(direction)
+        s = 'Placing '
+        if not (self._own_col and self._own_row):
+            s += 'partially '
+        s += '{} points in row {}.'.format(dir_str, idx)
+        return s
 
     def _point_placement_formal_step(self, cell, direction):
         return "Placing {} point in cell {}.".format(


### PR DESCRIPTION
Fix two problems with `RequirementPlacement`:

- [x] The formal step now indicate if the placement was partial
- [x] The `all_column_placement_rules` return rules when placing only on own column (returned nothing before)