### PR TITLE
Add ObstructionInferralStrategy

### DIFF
--- a/tests/algorithms/test_obstruction_inferral.py
+++ b/tests/algorithms/test_obstruction_inferral.py
@@ -255,13 +255,7 @@ class TestAllObstructionInferral(CommonTest):
         return AllObstructionInferral(tiling_not_inf, 3)
 
     def test_obstruction_length(self, obs_inf1):
-        assert obs_inf1.obstrucion_length == 2
-
-    def test_avoids_obstruction(self, obs_inf1):
-        assert obs_inf1.avoids_obstructions(Obstruction(Perm((0, 1)),
-                                                        ((0, 0), (1, 0))))
-        assert not obs_inf1.avoids_obstructions(
-            Obstruction(Perm((0, 1, 2)), ((0, 0), (0, 0), (1, 0))))
+        assert obs_inf1.obstruction_length == 2
 
     def test_not_required(self, obs_inf1):
         assert not obs_inf1.not_required(Requirement(Perm((0,)), ((1, 0),)))
@@ -283,18 +277,13 @@ class TestAllObstructionInferral(CommonTest):
 
     def test_potential_new_obs(self, obs_inf1, obs_not_inf):
         assert set(obs_inf1.potential_new_obs()) == set([
+            Obstruction(Perm((0,)), ((0, 0),)),
             Obstruction(Perm((0, 1)), ((0, 0), (0, 0))),
             Obstruction(Perm((0, 1)), ((0, 0), (1, 0))),
             Obstruction(Perm((1, 0)), ((0, 0), (1, 0))),
         ])
-        assert set(obs_not_inf.potential_new_obs()) == set([
-            Obstruction(Perm((0, 1, 2)), ((0, 0),)*3),
-            Obstruction(Perm((0, 2, 1)), ((0, 0),)*3),
-            Obstruction(Perm((1, 0, 2)), ((0, 0),)*3),
-            Obstruction(Perm((1, 2, 0)), ((0, 0),)*3),
-            Obstruction(Perm((2, 0, 1)), ((0, 0),)*3),
-            Obstruction(Perm((2, 1, 0)), ((0, 0),)*3),
-        ])
+        print(obs_not_inf._tiling)
+        assert set(obs_not_inf.potential_new_obs()) == set([])
 
     def test_new_obs(self, obs_inf1, obs_not_inf):
         assert set(obs_inf1.new_obs()) == set([

--- a/tilings/algorithms/obstruction_inferral.py
+++ b/tilings/algorithms/obstruction_inferral.py
@@ -85,22 +85,15 @@ class SubobstructionInferral(ObstructionInferral):
 class AllObstructionInferral(ObstructionInferral):
     """
     Algorithm to compute the tiling created by adding all
-    obstruction of given length which can be added.
+    obstruction of length up to obstruction_length which can be added.
     """
-    def __init__(self, tiling, obstrucion_length):
+    def __init__(self, tiling, obstruction_length):
         super().__init__(tiling)
-        self._obs_len = obstrucion_length
+        self._obs_len = obstruction_length
 
     @property
-    def obstrucion_length(self):
+    def obstruction_length(self):
         return self._obs_len
-
-    def avoids_obstructions(self, gp):
-        """
-        Return True if the gridded perm `gp` does not contains any obstruction
-        of the tiling.
-        """
-        return all(ob not in gp for ob in self._tiling.obstructions)
 
     def not_required(self, gp):
         """
@@ -114,10 +107,12 @@ class AllObstructionInferral(ObstructionInferral):
         """
         Iterator over all possible obstruction of `self.obstruction_length`.
         """
+        if not self._tiling.requirements:
+            return []
         no_req_tiling = self._tiling.__class__(self._tiling.obstructions)
         n = self._obs_len
         pot_obs = filter(self.not_required,
-                         no_req_tiling.gridded_perms_of_length(n))
+                         no_req_tiling.gridded_perms(n))
         return (Obstruction(gp.patt, gp.pos) for gp in pot_obs)
 
 

--- a/tilings/strategies/__init__.py
+++ b/tilings/strategies/__init__.py
@@ -6,7 +6,7 @@ from .batch import (AllCellInsertionStrategy, AllFactorInsertionStrategy,
 from .decomposition import FactorStrategy
 from .equivalence import RequirementPlacementStrategy
 from .fusion import ComponentFusionStrategy, FusionStrategy
-from .inferral import (EmptyCellInferralStrategy,
+from .inferral import (EmptyCellInferralStrategy, ObstructionInferralStrategy,
                        ObstructionTransitivityStrategy,
                        RowColumnSeparationStrategy,
                        SubobstructionInferralStrategy)
@@ -40,6 +40,7 @@ __all__ = [
 
     # Inferral
     'EmptyCellInferralStrategy',
+    'ObstructionInferralStrategy',
     'ObstructionTransitivityStrategy',
     'RowColumnSeparationStrategy',
     'SubobstructionInferralStrategy',

--- a/tilings/strategies/inferral.py
+++ b/tilings/strategies/inferral.py
@@ -2,8 +2,9 @@ from typing import Optional
 
 from comb_spec_searcher import Rule
 from tilings import Tiling
-from tilings.algorithms import (EmptyCellInferral, ObstructionTransitivity,
-                                RowColSeparation, SubobstructionInferral)
+from tilings.algorithms import (AllObstructionInferral, EmptyCellInferral,
+                                ObstructionTransitivity, RowColSeparation,
+                                SubobstructionInferral)
 from tilings.strategies.abstract_strategy import Strategy
 
 __all__ = [
@@ -11,6 +12,7 @@ __all__ = [
     'RowColumnSeparationStrategy',
     'EmptyCellInferralStrategy',
     'SubobstructionInferralStrategy',
+    'ObstructionInferralStrategy',
 ]
 
 
@@ -96,3 +98,30 @@ class SubobstructionInferralStrategy(Strategy):
     @classmethod
     def from_dict(cls, d: dict) -> 'SubobstructionInferralStrategy':
         return cls()
+
+
+class ObstructionInferralStrategy(Strategy):
+    """
+    Return tiling created by adding all obstructions of length up to maxlen
+    that can be added.
+    """
+    def __init__(self, maxlen: int = 3) -> None:
+        self.maxlen = maxlen
+
+    def __call__(self, tiling: Tiling, **kwargs) -> Optional[Rule]:
+        return AllObstructionInferral(tiling, self.maxlen).rule()
+
+    def __repr__(self) -> str:
+        return 'ObstructionInferralStrategy(maxlen={})'.format(self.maxlen)
+
+    def __str__(self) -> str:
+        return 'length {} obstruction inferral'.format(self.maxlen)
+
+    def to_jsonable(self) -> dict:
+        d = super().to_jsonable()
+        d['maxlen'] = self.maxlen
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> 'ObstructionInferralStrategy':
+        return cls(maxlen=d['maxlen'])

--- a/tilings/tiling.py
+++ b/tilings/tiling.py
@@ -785,8 +785,8 @@ class Tiling(CombinatorialClass):
 
     def all_obstruction_inferral(self, obstruction_length):
         """
-        Adds all the obstruction of length `obstruction_length` that doesn't
-        change the set of gridded permutations of the tiling.
+        Adds all the obstruction of length up to `obstruction_length` that
+        does not change the set of gridded permutations of the tiling.
         """
         obs_inf = AllObstructionInferral(self, obstruction_length)
         return obs_inf.obstruction_inferral()


### PR DESCRIPTION
Adding an strategy to infer any possible obstruction up to a given length.

The `AllObstructionInferral` has changed to reflect the fact that it is not
possible to add obstruction on a tiling without requirements.