### PR TITLE
Consider graph vertices in is_tree function

### DIFF
--- a/tests/algorithms/test_enumeration.py
+++ b/tests/algorithms/test_enumeration.py
@@ -344,6 +344,16 @@ class TestMonotoneTreeEnumeration(CommonTest):
         assert not enum_with_crossing.verified()
         assert not enum_with_list_req.verified()
         assert not onebyone_enum.verified()
+        forest_tiling = Tiling(obstructions=[
+            Obstruction(Perm((0,)), ((0, 0),)),
+            Obstruction(Perm((0,)), ((1, 1),)),
+            Obstruction(Perm((0,)), ((2, 1),)),
+            Obstruction(Perm((0, 1)), ((1, 0), (1, 0))),
+            Obstruction(Perm((0, 1)), ((2, 0), (2, 0))),
+            Obstruction(Perm((0, 1, 2)), ((0, 1), (0, 1), (0, 1))),
+        ], requirements=[[Requirement(Perm((0,)), ((0, 1),))]]
+        )
+        assert not MonotoneTreeEnumeration(forest_tiling).verified()
 
     @pytest.mark.xfail(reason='No database setup')
     def test_get_genf(self, enum_verified):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,4 +1,4 @@
-from tilings.misc import intersection_reduce, partitions_iterator
+from tilings.misc import intersection_reduce, is_tree, partitions_iterator
 
 
 def test_partitions_iterator():
@@ -16,3 +16,12 @@ def test_intersection_reduce():
     assert intersection_reduce([]) == set()
     assert intersection_reduce([(1, 2, 3), (2, 3, 4), (3, 4, 5)]) == set([3])
     assert intersection_reduce([(1, 2, 3)]) == set([1, 2, 3])
+
+
+def test_is_tree():
+    assert is_tree([], [])
+    assert is_tree([0], [])
+    assert not is_tree([0, 1], [])
+    assert not is_tree([0, 1, 2], [(0, 1)])
+    assert is_tree([0, 1, 2], [(0, 1), (1, 2)])
+    assert not is_tree([0, 1, 2], [(0, 1), (1, 2), (2, 0)])

--- a/tilings/algorithms/enumeration.py
+++ b/tilings/algorithms/enumeration.py
@@ -234,7 +234,7 @@ class MonotoneTreeEnumeration(Enumeration):
         num_non_monotone = sum(1 for c in self.tiling.active_cells
                                if not self.tiling.is_monotone_cell(c))
         return (local_verified and no_req_list and num_non_monotone <= 1 and
-                is_tree(self.tiling.cell_graph()))
+                is_tree(self.tiling.active_cells, self.tiling.cell_graph()))
 
     def _cell_tree_traversal(self, start):
         """

--- a/tilings/misc.py
+++ b/tilings/misc.py
@@ -2,8 +2,11 @@
 Collection of function that are not directly related to the code but still
 useful.
 """
-from collections import defaultdict
 from functools import reduce
+from typing import Dict, Sequence, Set, Tuple, TypeVar
+
+Vertex = TypeVar('Vertex')
+AdjTable = Dict[Vertex, Set[Vertex]]
 
 
 def map_cell(col_mapping, row_mapping, cell):
@@ -32,44 +35,44 @@ def intersection_reduce(iterable):
         return set()
 
 
-def is_tree(edges):
+def is_tree(vertices: Sequence[Vertex],
+            edges: Sequence[Tuple[Vertex, Vertex]]) -> bool:
     """
     Return True if the undirected graph is a tree.
 
     That is, it is has no cycles and is connected.
     """
-    adj_table = adjacency_table(edges)
-    return len(edges) + 1 == len(adj_table) and is_connected(adj_table)
+    if not vertices:
+        return True
+    adj_table = adjacency_table(vertices, edges)
+    return len(edges) + 1 == len(vertices) and is_connected(adj_table)
 
 
-def adjacency_table(edges):
+def adjacency_table(vertices: Sequence[Vertex],
+                    edges: Sequence[Tuple[Vertex, Vertex]]) -> AdjTable:
     """Return adjacency table of edges."""
-    adj_table = defaultdict(set)
+    adj_table = {v: set() for v in vertices}  # type: AdjTable
     for c1, c2 in edges:
         adj_table[c1].add(c2)
         adj_table[c2].add(c1)
     return adj_table
 
 
-def is_connected(adj_table):
+def is_connected(adj_table: AdjTable) -> bool:
     """Return True if graph with adjacency table is connected."""
     if not adj_table:
         return True
     visited = {cell: False for cell in adj_table}
-
-    # pick some start vertex
-
-    for start in adj_table:
-        break
-    # pylint: disable=undefined-loop-variable
-    queue = [start]
-    while queue:
-        curr = queue.pop()
+    start_vertex = next(iter(adj_table.keys()))
+    visited[start_vertex] = True
+    stack = [start_vertex]
+    while stack:
+        curr = stack.pop()
         for vertex in adj_table[curr]:
             if not visited[vertex]:
-                queue.append(vertex)
+                stack.append(vertex)
                 visited[vertex] = True
-    return all(x for x in visited.values())
+    return all(visited.values())
 
 # The code below is magical and comes from
 # https://codereview.stackexchange.com/questions/1526/finding-all-k-subset-partitions


### PR DESCRIPTION
I noticed a bug that made this tiling
```
+-+-+-+
|1| | |
+-+-+-+
| |\|\|
+-+-+-+
1: Av+(012)
\: Av(01)
Requirement 0:
0: (0, 1)
```
considered a monotone tree.

The bug was caused by the fact that the `is_tree` function only considered the
edges of the graph. Hence it was unable to spot an isolated vertex has it does
not appear in any edge.