### PR TITLE
Fixed a bug when starting the searcher with a tiling.

### DIFF
--- a/tests/test_tilescope.py
+++ b/tests/test_tilescope.py
@@ -4,7 +4,7 @@ import sympy
 from comb_spec_searcher import CombinatorialSpecification
 from comb_spec_searcher.utils import taylor_expand
 from permuta import Perm
-from tilings import Tiling
+from tilings import GriddedPerm, Tiling
 from tilings import strategies as strat
 from tilings.strategies.fusion import ComponentFusionStrategy, FusionStrategy
 from tilings.strategy_pack import TileScopePack
@@ -235,3 +235,18 @@ def test_321_1324():
         2119889,
         2350237,
     ]
+
+
+@pytest.mark.timeout(5)
+def test_from_tiling():
+    t = Tiling(
+        obstructions=[
+            GriddedPerm(Perm((0, 1)), ((0, 0), (0, 0))),
+            GriddedPerm(Perm((0, 1)), ((0, 0), (1, 1))),
+            GriddedPerm(Perm((0, 1)), ((1, 1), (1, 1))),
+        ]
+    )
+    searcher = TileScope(t, TileScopePack.point_placements())
+    spec = searcher.auto_search()
+    print(spec)
+    assert sympy.simplify(spec.get_genf() - sympy.sympify("(1+x)/(1-x)")) == 0

--- a/tilings/tilescope.py
+++ b/tilings/tilescope.py
@@ -36,11 +36,13 @@ class TileScope(CombinatorialSpecificationSearcher):
                 basis = Basis([o.patt for o in start_class.obstructions])
         elif isinstance(start_class, collections.Iterable):
             basis = Basis(start_class)
+            assert all(
+                isinstance(p, Perm) for p in basis
+            ), "Basis must contains Perm only"
         else:
             raise ValueError(
                 "start class must be a string, an iterable of Perm or a tiling"
             )
-        assert all(isinstance(p, Perm) for p in basis), "Basis must contains Perm only"
 
         if not isinstance(start_class, Tiling):
             start_tiling = Tiling(
@@ -51,13 +53,8 @@ class TileScope(CombinatorialSpecificationSearcher):
             logger.info("Fixing basis in OneByOneVerificationStrategy")
             strategy_pack = strategy_pack.fix_one_by_one(basis)
 
-        function_kwargs = {"basis": basis}
         super().__init__(
-            start_tiling,
-            strategy_pack,
-            function_kwargs=function_kwargs,
-            logger_kwargs=logger_kwargs,
-            **kwargs,
+            start_tiling, strategy_pack, logger_kwargs=logger_kwargs, **kwargs,
         )
 
     @staticmethod


### PR DESCRIPTION
There's was a bug with an assertion when trying to start the tilescope
with the tiling that is not 1x1. I moved the asssert so that it's not a
problem anymore.

I also removed the basis function_kwargs as it's not something we use
anymore.