### PR TITLE
fix a bug that occurred when composing cell map

### DIFF
--- a/tests/algorithms/test_row_col_separation.py
+++ b/tests/algorithms/test_row_col_separation.py
@@ -997,3 +997,64 @@ def test_backmap2():
     rcs = RowColSeparation(t)
     assert rcs.separated_tiling() == t2
     assert RowColSeparation(t).get_cell_map() == final_cell_map
+
+
+def test_backmap3():
+    t = Tiling(
+        obstructions=(
+            GriddedPerm(Perm((0, 1)), ((0, 0), (0, 0))),
+            GriddedPerm(Perm((0, 1)), ((0, 0), (0, 1))),
+            GriddedPerm(Perm((0, 1)), ((0, 0), (0, 2))),
+            GriddedPerm(Perm((0, 1)), ((0, 0), (1, 1))),
+            GriddedPerm(Perm((0, 1)), ((0, 0), (2, 0))),
+            GriddedPerm(Perm((0, 1)), ((0, 0), (2, 2))),
+            GriddedPerm(Perm((0, 1)), ((0, 1), (0, 2))),
+            GriddedPerm(Perm((0, 1)), ((0, 1), (1, 1))),
+            GriddedPerm(Perm((0, 1)), ((0, 2), (0, 2))),
+            GriddedPerm(Perm((0, 1)), ((1, 1), (1, 1))),
+            GriddedPerm(Perm((0, 1)), ((1, 1), (2, 1))),
+            GriddedPerm(Perm((0, 1)), ((2, 0), (2, 0))),
+            GriddedPerm(Perm((1, 0)), ((0, 0), (2, 0))),
+            GriddedPerm(Perm((1, 0)), ((0, 1), (0, 0))),
+            GriddedPerm(Perm((1, 0)), ((0, 1), (2, 1))),
+            GriddedPerm(Perm((1, 0)), ((0, 2), (0, 0))),
+            GriddedPerm(Perm((1, 0)), ((0, 2), (0, 1))),
+            GriddedPerm(Perm((1, 0)), ((1, 1), (2, 1))),
+            GriddedPerm(Perm((1, 0)), ((2, 1), (2, 0))),
+            GriddedPerm(Perm((1, 0)), ((2, 1), (2, 1))),
+            GriddedPerm(Perm((1, 0)), ((2, 2), (2, 1))),
+            GriddedPerm(Perm((0, 1, 2)), ((0, 1), (0, 1), (2, 1))),
+            GriddedPerm(Perm((0, 1, 2)), ((0, 1), (2, 1), (2, 2))),
+            GriddedPerm(Perm((0, 2, 1)), ((0, 1), (0, 1), (0, 1))),
+            GriddedPerm(Perm((0, 2, 1)), ((0, 1), (2, 2), (2, 2))),
+            GriddedPerm(Perm((0, 2, 1)), ((2, 1), (2, 2), (2, 2))),
+            GriddedPerm(Perm((0, 2, 1)), ((2, 2), (2, 2), (2, 2))),
+            GriddedPerm(Perm((1, 0, 2)), ((2, 2), (2, 2), (2, 2))),
+            GriddedPerm(Perm((1, 2, 0)), ((0, 2), (2, 2), (2, 2))),
+            GriddedPerm(Perm((1, 2, 0)), ((2, 2), (2, 2), (2, 2))),
+            GriddedPerm(Perm((2, 0, 1)), ((0, 1), (0, 1), (0, 1))),
+            GriddedPerm(Perm((2, 0, 1)), ((2, 2), (2, 0), (2, 2))),
+            GriddedPerm(Perm((2, 0, 1)), ((2, 2), (2, 2), (2, 2))),
+            GriddedPerm(Perm((2, 1, 0)), ((0, 2), (2, 2), (2, 0))),
+            GriddedPerm(Perm((2, 1, 0)), ((0, 2), (2, 2), (2, 2))),
+            GriddedPerm(Perm((2, 1, 0)), ((2, 2), (2, 2), (2, 0))),
+            GriddedPerm(Perm((2, 1, 0)), ((2, 2), (2, 2), (2, 2))),
+        ),
+        requirements=((GriddedPerm(Perm((0,)), ((2, 1),)),),),
+    )
+    cellmap1 = {
+        (0, 0): (2, 0),
+        (0, 1): (0, 2),
+        (0, 2): (1, 4),
+        (2, 0): (3, 1),
+        (2, 1): (3, 3),
+        (2, 2): (3, 4),
+    }
+    print(t)
+    rcs1 = _RowColSeparationSingleApplication(t)
+    t1 = rcs1.separated_tiling()
+    print(t1)
+    assert rcs1.get_cell_map() == cellmap1
+    rcs = RowColSeparation(t)
+    assert rcs.separated_tiling() == t1
+    assert rcs.get_cell_map() == cellmap1

--- a/tests/algorithms/test_row_col_separation.py
+++ b/tests/algorithms/test_row_col_separation.py
@@ -867,3 +867,68 @@ def test_multiple_separation():
         ),
     )
     assert seprated_tiling == expected_tiling
+
+
+def test_backmap():
+    t = Tiling(
+        obstructions=(
+            GriddedPerm(Perm((0,)), ((0, 0),)),
+            GriddedPerm(Perm((0, 1)), ((0, 1), (0, 1))),
+            GriddedPerm(Perm((0, 1)), ((0, 2), (0, 2))),
+            GriddedPerm(Perm((0, 1)), ((0, 2), (1, 2))),
+            GriddedPerm(Perm((0, 1)), ((1, 0), (1, 2))),
+            GriddedPerm(Perm((0, 1)), ((1, 1), (1, 2))),
+            GriddedPerm(Perm((0, 1)), ((1, 2), (1, 2))),
+            GriddedPerm(Perm((1, 0)), ((0, 2), (1, 2))),
+            GriddedPerm(Perm((1, 0)), ((1, 1), (1, 1))),
+            GriddedPerm(Perm((1, 0)), ((1, 2), (1, 2))),
+            GriddedPerm(Perm((0, 2, 1)), ((0, 1), (0, 2), (0, 2))),
+            GriddedPerm(Perm((0, 2, 1)), ((1, 0), (1, 0), (1, 0))),
+            GriddedPerm(Perm((0, 2, 1)), ((1, 0), (1, 1), (1, 0))),
+            GriddedPerm(Perm((1, 2, 0)), ((0, 1), (0, 2), (1, 1))),
+            GriddedPerm(Perm((1, 2, 0)), ((0, 1), (1, 2), (1, 1))),
+            GriddedPerm(Perm((1, 2, 0)), ((1, 0), (1, 0), (1, 0))),
+            GriddedPerm(Perm((2, 0, 1)), ((0, 2), (0, 1), (0, 2))),
+            GriddedPerm(Perm((2, 0, 1)), ((1, 1), (1, 0), (1, 0))),
+            GriddedPerm(Perm((2, 0, 1)), ((1, 2), (1, 0), (1, 0))),
+            GriddedPerm(Perm((2, 1, 0)), ((0, 1), (1, 1), (1, 0))),
+            GriddedPerm(Perm((2, 1, 0)), ((0, 2), (1, 1), (1, 0))),
+            GriddedPerm(Perm((2, 1, 0)), ((1, 2), (1, 1), (1, 0))),
+            GriddedPerm(Perm((2, 3, 0, 1)), ((0, 1), (0, 2), (1, 0), (1, 0))),
+        ),
+        requirements=((GriddedPerm(Perm((0,)), ((1, 2),)),),),
+        assumptions=(),
+    )
+
+    cellmap1 = {
+        (0, 1): (0, 1),
+        (0, 2): (0, 3),
+        (1, 0): (2, 0),
+        (1, 1): (2, 1),
+        (1, 2): (1, 2),
+    }
+    cellmap2 = {
+        (0, 1): (0, 1),
+        (1, 2): (1, 3),
+        (2, 0): (2, 0),
+        (2, 1): (3, 2),
+    }
+    final_cell_map = {
+        (0, 1): (0, 1),
+        (1, 0): (2, 0),
+        (1, 1): (3, 2),
+        (1, 2): (1, 3),
+    }
+    rcs1 = _RowColSeparationSingleApplication(t)
+    t1 = rcs1.separated_tiling()
+    roworder1 = rcs1.max_row_order
+    colorder1 = rcs1.max_col_order
+    assert rcs1.get_cell_map(roworder1, colorder1) == cellmap1
+    rcs2 = _RowColSeparationSingleApplication(t1)
+    t2 = rcs2.separated_tiling()
+    roworder2 = rcs2.max_row_order
+    colorder2 = rcs2.max_col_order
+    assert rcs2.get_cell_map(roworder2, colorder2) == cellmap2
+    rcs = RowColSeparation(t)
+    assert rcs.separated_tiling() == t2
+    assert RowColSeparation(t).get_cell_map() == final_cell_map

--- a/tests/algorithms/test_row_col_separation.py
+++ b/tests/algorithms/test_row_col_separation.py
@@ -899,10 +899,8 @@ def test_backmap():
         requirements=((GriddedPerm(Perm((0,)), ((1, 2),)),),),
         assumptions=(),
     )
-
     cellmap1 = {
         (0, 1): (0, 1),
-        (0, 2): (0, 3),
         (1, 0): (2, 0),
         (1, 1): (2, 1),
         (1, 2): (1, 2),
@@ -921,14 +919,81 @@ def test_backmap():
     }
     rcs1 = _RowColSeparationSingleApplication(t)
     t1 = rcs1.separated_tiling()
-    roworder1 = rcs1.max_row_order
-    colorder1 = rcs1.max_col_order
-    assert rcs1.get_cell_map(roworder1, colorder1) == cellmap1
+    assert rcs1.get_cell_map() == cellmap1
     rcs2 = _RowColSeparationSingleApplication(t1)
     t2 = rcs2.separated_tiling()
-    roworder2 = rcs2.max_row_order
-    colorder2 = rcs2.max_col_order
-    assert rcs2.get_cell_map(roworder2, colorder2) == cellmap2
+    assert rcs2.get_cell_map() == cellmap2
+    rcs = RowColSeparation(t)
+    assert rcs.separated_tiling() == t2
+    assert RowColSeparation(t).get_cell_map() == final_cell_map
+
+
+def test_backmap2():
+    t = Tiling(
+        obstructions=(
+            GriddedPerm(Perm((0, 1)), ((0, 0), (1, 2))),
+            GriddedPerm(Perm((0, 1)), ((0, 0), (2, 2))),
+            GriddedPerm(Perm((0, 1)), ((0, 2), (0, 2))),
+            GriddedPerm(Perm((0, 1)), ((1, 0), (2, 0))),
+            GriddedPerm(Perm((0, 1)), ((1, 1), (1, 1))),
+            GriddedPerm(Perm((0, 1)), ((2, 0), (2, 0))),
+            GriddedPerm(Perm((1, 0)), ((0, 0), (0, 0))),
+            GriddedPerm(Perm((1, 0)), ((0, 0), (1, 0))),
+            GriddedPerm(Perm((1, 0)), ((0, 0), (2, 0))),
+            GriddedPerm(Perm((1, 0)), ((0, 2), (1, 2))),
+            GriddedPerm(Perm((1, 0)), ((1, 0), (2, 0))),
+            GriddedPerm(Perm((1, 0)), ((1, 1), (1, 0))),
+            GriddedPerm(Perm((1, 0)), ((1, 2), (1, 0))),
+            GriddedPerm(Perm((1, 0)), ((1, 2), (1, 2))),
+            GriddedPerm(Perm((1, 0)), ((1, 2), (2, 2))),
+            GriddedPerm(Perm((1, 0)), ((2, 2), (2, 2))),
+            GriddedPerm(Perm((0, 1, 2)), ((1, 0), (1, 1), (1, 2))),
+            GriddedPerm(Perm((0, 1, 2)), ((1, 0), (1, 1), (2, 2))),
+            GriddedPerm(Perm((0, 1, 2)), ((1, 0), (1, 2), (1, 2))),
+            GriddedPerm(Perm((0, 1, 2)), ((1, 0), (1, 2), (2, 2))),
+            GriddedPerm(Perm((0, 2, 1)), ((0, 0), (1, 0), (1, 0))),
+            GriddedPerm(Perm((0, 2, 1)), ((1, 0), (1, 0), (1, 0))),
+            GriddedPerm(Perm((1, 0, 2)), ((1, 0), (1, 0), (1, 1))),
+            GriddedPerm(Perm((1, 0, 2)), ((1, 0), (1, 0), (1, 2))),
+            GriddedPerm(Perm((1, 2, 0)), ((1, 0), (1, 0), (1, 0))),
+            GriddedPerm(Perm((2, 0, 1)), ((1, 0), (1, 0), (1, 0))),
+            GriddedPerm(Perm((2, 1, 0)), ((0, 2), (2, 2), (2, 0))),
+        ),
+        requirements=((GriddedPerm(Perm((0,)), ((1, 0),)),),),
+    )
+    cellmap1 = {
+        (0, 0): (0, 0),
+        (0, 2): (0, 3),
+        (1, 0): (1, 1),
+        (1, 1): (2, 2),
+        (1, 2): (2, 3),
+        (2, 2): (3, 3),
+    }
+    cellmap2 = {
+        (0, 0): (0, 0),
+        (0, 3): (0, 3),
+        (1, 1): (1, 1),
+        (2, 2): (3, 2),
+        (2, 3): (2, 4),
+        (3, 3): (4, 3),
+    }
+    final_cell_map = {
+        (0, 0): (0, 0),
+        (0, 2): (0, 3),
+        (1, 0): (1, 1),
+        (1, 1): (3, 2),
+        (1, 2): (2, 4),
+        (2, 2): (4, 3),
+    }
+    print(t)
+    rcs1 = _RowColSeparationSingleApplication(t)
+    t1 = rcs1.separated_tiling()
+    print(t1)
+    assert rcs1.get_cell_map() == cellmap1
+    rcs2 = _RowColSeparationSingleApplication(t1)
+    t2 = rcs2.separated_tiling()
+    print(t2)
+    assert rcs2.get_cell_map() == cellmap2
     rcs = RowColSeparation(t)
     assert rcs.separated_tiling() == t2
     assert RowColSeparation(t).get_cell_map() == final_cell_map

--- a/tests/strategies/test_row_column_separation.py
+++ b/tests/strategies/test_row_column_separation.py
@@ -221,7 +221,7 @@ def test_formal_step(seperable_tiling1):
     )
 
 
-def test_back_map():
+def test_backmap():
     tiling = Tiling(
         obstructions=(
             GriddedPerm(Perm((0,)), ((1, 1),)),
@@ -246,11 +246,68 @@ def test_back_map():
         ),
         requirements=((GriddedPerm(Perm((0,)), ((1, 0),)),),),
     )
-
     strategy = RowColumnSeparationStrategy()
-
     rule = strategy(tiling)
-
     gps = (GriddedPerm(Perm((0,)), ((1, 2),)),)
-
     assert rule.backward_map(gps) == GriddedPerm(Perm((0,)), ((0, 1),))
+
+
+def test_maps():
+    t = Tiling(
+        obstructions=(
+            GriddedPerm(Perm((0, 1)), ((0, 0), (0, 0))),
+            GriddedPerm(Perm((0, 1)), ((0, 0), (0, 1))),
+            GriddedPerm(Perm((0, 1)), ((0, 0), (0, 2))),
+            GriddedPerm(Perm((0, 1)), ((0, 0), (1, 1))),
+            GriddedPerm(Perm((0, 1)), ((0, 0), (2, 0))),
+            GriddedPerm(Perm((0, 1)), ((0, 0), (2, 2))),
+            GriddedPerm(Perm((0, 1)), ((0, 1), (0, 2))),
+            GriddedPerm(Perm((0, 1)), ((0, 1), (1, 1))),
+            GriddedPerm(Perm((0, 1)), ((0, 2), (0, 2))),
+            GriddedPerm(Perm((0, 1)), ((1, 1), (1, 1))),
+            GriddedPerm(Perm((0, 1)), ((1, 1), (2, 1))),
+            GriddedPerm(Perm((0, 1)), ((2, 0), (2, 0))),
+            GriddedPerm(Perm((1, 0)), ((0, 0), (2, 0))),
+            GriddedPerm(Perm((1, 0)), ((0, 1), (0, 0))),
+            GriddedPerm(Perm((1, 0)), ((0, 1), (2, 1))),
+            GriddedPerm(Perm((1, 0)), ((0, 2), (0, 0))),
+            GriddedPerm(Perm((1, 0)), ((0, 2), (0, 1))),
+            GriddedPerm(Perm((1, 0)), ((1, 1), (2, 1))),
+            GriddedPerm(Perm((1, 0)), ((2, 1), (2, 0))),
+            GriddedPerm(Perm((1, 0)), ((2, 1), (2, 1))),
+            GriddedPerm(Perm((1, 0)), ((2, 2), (2, 1))),
+            GriddedPerm(Perm((0, 1, 2)), ((0, 1), (0, 1), (2, 1))),
+            GriddedPerm(Perm((0, 1, 2)), ((0, 1), (2, 1), (2, 2))),
+            GriddedPerm(Perm((0, 2, 1)), ((0, 1), (0, 1), (0, 1))),
+            GriddedPerm(Perm((0, 2, 1)), ((0, 1), (2, 2), (2, 2))),
+            GriddedPerm(Perm((0, 2, 1)), ((2, 1), (2, 2), (2, 2))),
+            GriddedPerm(Perm((0, 2, 1)), ((2, 2), (2, 2), (2, 2))),
+            GriddedPerm(Perm((1, 0, 2)), ((2, 2), (2, 2), (2, 2))),
+            GriddedPerm(Perm((1, 2, 0)), ((0, 2), (2, 2), (2, 2))),
+            GriddedPerm(Perm((1, 2, 0)), ((2, 2), (2, 2), (2, 2))),
+            GriddedPerm(Perm((2, 0, 1)), ((0, 1), (0, 1), (0, 1))),
+            GriddedPerm(Perm((2, 0, 1)), ((2, 2), (2, 0), (2, 2))),
+            GriddedPerm(Perm((2, 0, 1)), ((2, 2), (2, 2), (2, 2))),
+            GriddedPerm(Perm((2, 1, 0)), ((0, 2), (2, 2), (2, 0))),
+            GriddedPerm(Perm((2, 1, 0)), ((0, 2), (2, 2), (2, 2))),
+            GriddedPerm(Perm((2, 1, 0)), ((2, 2), (2, 2), (2, 0))),
+            GriddedPerm(Perm((2, 1, 0)), ((2, 2), (2, 2), (2, 2))),
+        ),
+        requirements=((GriddedPerm(Perm((0,)), ((2, 1),)),),),
+    )
+    print(t)
+    print(t.row_and_column_separation())
+    strategy = RowColumnSeparationStrategy()
+    rule = strategy(t)
+    cell_pre_sep = [(0, 0), (0, 1), (0, 2), (2, 0), (2, 1), (2, 2)]
+    cell_post_sep = [(2, 0), (0, 2), (1, 4), (3, 1), (3, 3), (3, 4)]
+    # Testing forward map
+    for cell, image in zip(cell_pre_sep, cell_post_sep):
+        gp = GriddedPerm(Perm((0,)), (cell,))
+        print(f"{cell} -> {image}")
+        assert rule.forward_map(gp) == (GriddedPerm(Perm((0,)), (image,)),)
+    # Testing backmap
+    for cell, image in zip(cell_post_sep, cell_pre_sep):
+        gps = [GriddedPerm(Perm((0,)), (cell,))]
+        print(f"{cell} -> {image}")
+        assert rule.backward_map(gps) == GriddedPerm(Perm((0,)), (image,))

--- a/tilings/algorithms/row_col_separation.py
+++ b/tilings/algorithms/row_col_separation.py
@@ -559,15 +559,13 @@ class RowColSeparation:
         """
         separation_algo = _RowColSeparationSingleApplication(self._tiling)
         cell_maps = []
-        step_tilings = [self._tiling]
         while separation_algo.separable():
             cell_map = separation_algo.get_cell_map()
             cell_maps.append(cell_map)
             new_sep = separation_algo.separated_tiling()
-            step_tilings.append(new_sep)
             separation_algo = _RowColSeparationSingleApplication(new_sep)
         res = {cell: cell for cell in self._tiling.active_cells}
-        for cell_map, start_tiling in zip(cell_maps, step_tilings):
+        for cell_map in cell_maps:
             for cell, mapped_cell in tuple(res.items()):
                 if mapped_cell in cell_map:
                     res[cell] = cell_map[mapped_cell]

--- a/tilings/strategies/row_and_col_separation.py
+++ b/tilings/strategies/row_and_col_separation.py
@@ -2,7 +2,7 @@
 The row and column separation strategy. The details of the algorithm can be
 found in the algorithms folder.
 """
-from typing import Dict, Optional, Tuple, cast
+from typing import Dict, Optional, Tuple
 
 from comb_spec_searcher import DisjointUnionStrategy
 from tilings import GriddedPerm, Tiling
@@ -68,13 +68,10 @@ class RowColumnSeparationStrategy(DisjointUnionStrategy[Tiling, GriddedPerm]):
         """This method will enable us to generate objects, and sample. """
         if children is None:
             children = self.decomposition_function(tiling)
-        gp = children[0].backward_map(cast(GriddedPerm, gps[0]))
+        gp = gps[0]
+        assert gp is not None
         backmap = self.backward_cell_map(tiling)
-
-        def mapping(c: Cell) -> Cell:
-            return backmap[c]
-
-        return gp.apply_map(mapping)
+        return gp.apply_map(backmap.__getitem__)
 
     def forward_map(
         self,
@@ -86,12 +83,8 @@ class RowColumnSeparationStrategy(DisjointUnionStrategy[Tiling, GriddedPerm]):
         if children is None:
             children = self.decomposition_function(tiling)
         forwardmap = self.forward_cell_map(tiling)
-
-        def mapping(c: Cell) -> Cell:
-            return forwardmap[c]
-
-        gp = gp.apply_map(mapping)
-        return (children[0].forward_map(gp),)
+        gp = gp.apply_map(forwardmap.__getitem__)
+        return (gp,)
 
     def __str__(self) -> str:
         return "row and column separation"


### PR DESCRIPTION
When row columns separation discovered an empty cell in one of it's
step. It caused a bug when composing the cell maps. This commit fixes by
removing from the final cell maps the cell that are mapped to non-active
cell.

This closes #126 