### PR TITLE
Fix a bug where the empty-obstruction Tiling was being modified

### DIFF
--- a/tests/test_tiling.py
+++ b/tests/test_tiling.py
@@ -2272,6 +2272,18 @@ def test_partial_place_col(obs_inf_til):
     )
 
 
+def test_empty_obstruction():
+    t = Tiling((GriddedPerm.empty_perm(),))
+    assert t.forward_cell_map == {}
+    assert t.obstructions == (GriddedPerm.empty_perm(),)
+
+
+def test_point_obstruction():
+    t = Tiling((GriddedPerm(Perm((0,)), ((0, 0),)),))
+    assert t.forward_cell_map == {}
+    assert t.obstructions == (GriddedPerm(Perm((0,)), ((0, 0),)),)
+
+
 class TestGetGenf:
     """
     Group all the test regarding getting the generating function for a tiling.

--- a/tilings/__init__.py
+++ b/tilings/__init__.py
@@ -1,4 +1,5 @@
+from tilings.assumptions import TrackingAssumption
 from tilings.griddedperm import GriddedPerm
 from tilings.tiling import Tiling
 
-__all__ = ["GriddedPerm", "Tiling"]
+__all__ = ["GriddedPerm", "Tiling", "TrackingAssumption"]

--- a/tilings/tiling.py
+++ b/tilings/tiling.py
@@ -223,7 +223,6 @@ class Tiling(CombinatorialClass):
             new_point_obstructions = tuple(
                 GriddedPerm(Perm((0,)), (cell,)) for cell in empty_cells
             )
-
             self._obstructions = new_point_obstructions + non_point_obstructions
 
         self._cached_properties["active_cells"] = frozenset(active_cells)

--- a/tilings/tiling.py
+++ b/tilings/tiling.py
@@ -151,6 +151,20 @@ class Tiling(CombinatorialClass):
             if remove_empty_rows_and_cols:
                 self._remove_empty_rows_and_cols()
 
+        else:
+            self._obstructions = (GriddedPerm.empty_perm(),)
+            self._requirements = tuple()
+            self._assumptions = tuple()
+            self._cached_properties["active_cells"] = frozenset()
+            self._cached_properties["backward_map"] = {}
+            self._cached_properties["cell_basis"] = {(0, 0): ([Perm()], [])}
+            self._cached_properties["dimensions"] = (1, 1)
+            self._cached_properties["empty_cells"] = frozenset([(0, 0)])
+            self._cached_properties["forward_map"] = {}
+            self._cached_properties["point_cells"] = frozenset()
+            self._cached_properties["positive_cells"] = frozenset()
+            self._cached_properties["possibly_empty"] = frozenset()
+
     @classmethod
     def from_perms(
         cls,
@@ -209,6 +223,7 @@ class Tiling(CombinatorialClass):
             new_point_obstructions = tuple(
                 GriddedPerm(Perm((0,)), (cell,)) for cell in empty_cells
             )
+
             self._obstructions = new_point_obstructions + non_point_obstructions
 
         self._cached_properties["active_cells"] = frozenset(active_cells)
@@ -239,9 +254,11 @@ class Tiling(CombinatorialClass):
         """Remove empty rows and columns."""
         # Produce the mapping between the two tilings
         if not self.active_cells:
+            assert GriddedPerm.empty_perm() not in self.obstructions
             self._cached_properties["forward_map"] = {}
             self._obstructions = (GriddedPerm.single_cell(Perm((0,)), (0, 0)),)
             self._requirements = tuple()
+            self._assumptions = tuple()
             self._cached_properties["dimensions"] = (1, 1)
             return
         col_mapping, row_mapping, identity = self._minimize_mapping()


### PR DESCRIPTION
Code that caused error:
[message (24).txt](https://github.com/PermutaTriangle/Tilings/files/4738437/message.24.txt)

The function `_remove_empty_rows_and_cols` was being called when `forward_cell_map` was needed, and the obstructions were being changed.
