### PR TITLE
flip extra parameters to be {parent: child}

### DIFF
--- a/tests/strategies/test_point_placements.py
+++ b/tests/strategies/test_point_placements.py
@@ -1218,7 +1218,7 @@ def test_reverse_rule_non_empty_children():
         reverse_rule.sanity_check(i)
 
 
-@pytest.mark.xfail("needs updated sanity checker on multivariables")
+@pytest.mark.xfail(reason="needs updated sanity checker on multivariables")
 def test_multiple_parent_parameters_to_same_child_parameter():
     tiling = Tiling(
         obstructions=(

--- a/tests/strategies/test_point_placements.py
+++ b/tests/strategies/test_point_placements.py
@@ -5,6 +5,7 @@ from comb_spec_searcher.strategies import Rule
 from permuta import Perm
 from permuta.misc import DIR_EAST, DIR_NORTH, DIR_SOUTH, DIR_WEST, DIRS
 from tilings import GriddedPerm, Tiling
+from tilings.assumptions import TrackingAssumption
 from tilings.strategies import (
     AllPlacementsFactory,
     PatternPlacementFactory,

--- a/tests/strategies/test_point_placements.py
+++ b/tests/strategies/test_point_placements.py
@@ -1215,3 +1215,58 @@ def test_reverse_rule_non_empty_children():
     reverse_rule = eqv_rule.to_reverse_rule()
     for i in range(6):
         reverse_rule.sanity_check(i)
+
+
+@pytest.mark.xfail("needs updated sanity checker on multivariables")
+def test_multiple_parent_parameters_to_same_child_parameter():
+    tiling = Tiling(
+        obstructions=(
+            GriddedPerm(Perm((0, 1)), ((1, 0), (1, 0))),
+            GriddedPerm(Perm((0, 1)), ((2, 0), (2, 0))),
+            GriddedPerm(Perm((0, 1)), ((2, 0), (3, 0))),
+            GriddedPerm(Perm((0, 1)), ((3, 0), (3, 0))),
+            GriddedPerm(Perm((1, 2, 0)), ((1, 0), (2, 0), (2, 0))),
+            GriddedPerm(Perm((1, 2, 0)), ((1, 0), (2, 0), (3, 0))),
+            GriddedPerm(Perm((1, 2, 0)), ((1, 0), (3, 0), (3, 0))),
+            GriddedPerm(Perm((0, 1, 2, 3)), ((0, 0), (0, 0), (0, 0), (0, 0))),
+            GriddedPerm(Perm((0, 1, 2, 3)), ((0, 0), (0, 0), (0, 0), (1, 0))),
+            GriddedPerm(Perm((0, 1, 2, 3)), ((0, 0), (0, 0), (0, 0), (2, 0))),
+            GriddedPerm(Perm((0, 1, 2, 3)), ((0, 0), (0, 0), (0, 0), (3, 0))),
+            GriddedPerm(Perm((0, 1, 2, 3)), ((0, 0), (0, 0), (1, 0), (2, 0))),
+            GriddedPerm(Perm((0, 1, 2, 3)), ((0, 0), (0, 0), (1, 0), (3, 0))),
+            GriddedPerm(Perm((0, 2, 3, 1)), ((0, 0), (0, 0), (0, 0), (0, 0))),
+            GriddedPerm(Perm((0, 2, 3, 1)), ((0, 0), (0, 0), (0, 0), (1, 0))),
+            GriddedPerm(Perm((0, 2, 3, 1)), ((0, 0), (0, 0), (0, 0), (2, 0))),
+            GriddedPerm(Perm((0, 2, 3, 1)), ((0, 0), (0, 0), (0, 0), (3, 0))),
+            GriddedPerm(Perm((0, 2, 3, 1)), ((0, 0), (0, 0), (1, 0), (1, 0))),
+            GriddedPerm(Perm((0, 2, 3, 1)), ((0, 0), (0, 0), (1, 0), (2, 0))),
+            GriddedPerm(Perm((0, 2, 3, 1)), ((0, 0), (0, 0), (1, 0), (3, 0))),
+            GriddedPerm(Perm((0, 2, 3, 1)), ((0, 0), (0, 0), (2, 0), (2, 0))),
+            GriddedPerm(Perm((0, 2, 3, 1)), ((0, 0), (0, 0), (2, 0), (3, 0))),
+            GriddedPerm(Perm((0, 2, 3, 1)), ((0, 0), (0, 0), (3, 0), (3, 0))),
+        ),
+        requirements=(),
+        assumptions=(
+            TrackingAssumption((GriddedPerm(Perm((0,)), ((2, 0),)),)),
+            TrackingAssumption(
+                (GriddedPerm(Perm((0,)), ((2, 0),)), GriddedPerm(Perm((0,)), ((3, 0),)))
+            ),
+        ),
+    )
+    strategy = RequirementPlacementStrategy(
+        gps=(
+            GriddedPerm(Perm((0,)), ((1, 0),)),
+            GriddedPerm(Perm((0,)), ((2, 0),)),
+            GriddedPerm(Perm((0,)), ((3, 0),)),
+            GriddedPerm(Perm((0,)), ((0, 0),)),
+        ),
+        indices=(0, 0, 0, 0),
+        direction=3,
+        own_col=True,
+        own_row=True,
+        ignore_parent=False,
+        include_empty=True,
+    )
+    rule = strategy(tiling)
+    for i in range(6):
+        rule.sanity_check(i)

--- a/tilings/strategies/factor.py
+++ b/tilings/strategies/factor.py
@@ -63,7 +63,7 @@ class FactorStrategy(CartesianProductStrategy[Tiling, GriddedPerm]):
                         children[i].forward_map(gp) for gp in assumption.gps
                     )
                     child_var = children[i].get_parameter(new_assumption)
-                    extra_parameters[i][child_var] = parent_var
+                    extra_parameters[i][parent_var] = child_var
                     break
             else:
                 raise ValueError("Assumption was not mapped to any child")

--- a/tilings/strategies/obstruction_inferral.py
+++ b/tilings/strategies/obstruction_inferral.py
@@ -63,7 +63,7 @@ class ObstructionInferralStrategy(DisjointUnionStrategy[Tiling, GriddedPerm]):
             if mapped_assumption.gps:
                 parent_var = comb_class.get_parameter(assumption)
                 child_var = av.get_parameter(mapped_assumption)
-                av_params[child_var] = parent_var
+                av_params[parent_var] = child_var
         return (av_params,)
 
     def backward_map(

--- a/tilings/strategies/requirement_insertion.py
+++ b/tilings/strategies/requirement_insertion.py
@@ -110,14 +110,14 @@ class RequirementInsertionStrategy(DisjointUnionStrategy[Tiling, GriddedPerm]):
             if mapped_assumption.gps:
                 parent_var = comb_class.get_parameter(assumption)
                 child_var = av.get_parameter(mapped_assumption)
-                av_params[child_var] = parent_var
+                av_params[parent_var] = child_var
 
         co_params: Dict[str, str] = {}
         for assumption, mapped_assumption in zip(comb_class.assumptions, co_mapped_ass):
             if mapped_assumption.gps:
                 parent_var = comb_class.get_parameter(assumption)
                 child_var = co.get_parameter(mapped_assumption)
-                co_params[child_var] = parent_var
+                co_params[parent_var] = child_var
         return av_params, co_params
 
     def __repr__(self) -> str:

--- a/tilings/strategies/requirement_placement.py
+++ b/tilings/strategies/requirement_placement.py
@@ -90,7 +90,7 @@ class RequirementPlacementStrategy(DisjointUnionStrategy[Tiling, GriddedPerm]):
                 if mapped_assumption.gps:
                     parent_var = comb_class.get_parameter(assumption)
                     child_var = child.get_parameter(mapped_assumption)
-                    extra_parameters[0][child_var] = parent_var
+                    extra_parameters[0][parent_var] = child_var
         for idx, (cell, child) in enumerate(
             zip(self._placed_cells, children[1:] if self.include_empty else children)
         ):
@@ -119,8 +119,8 @@ class RequirementPlacementStrategy(DisjointUnionStrategy[Tiling, GriddedPerm]):
                     parent_var = comb_class.get_parameter(assumption)
                     child_var = child.get_parameter(mapped_assumption)
                     extra_parameters[idx + 1 if self.include_empty else idx][
-                        child_var
-                    ] = parent_var
+                        parent_var
+                    ] = child_var
         return extra_parameters
 
     def direction_string(self):

--- a/tilings/strategies/row_and_col_separation.py
+++ b/tilings/strategies/row_and_col_separation.py
@@ -70,8 +70,8 @@ class RowColumnSeparationStrategy(DisjointUnionStrategy[Tiling, GriddedPerm]):
         )
         return (
             {
-                child.get_parameter(mapped_assumption): comb_class.get_parameter(
-                    assumption
+                comb_class.get_parameter(assumption): child.get_parameter(
+                    mapped_assumption
                 )
                 for assumption, mapped_assumption in zip(
                     comb_class.assumptions, mapped_assumptions


### PR DESCRIPTION
This necessary change captures the case when two parent parameters map to the same child parameter, if for example a cell becomes empty. It relies on the corresponding PR on CSS.

