### PR TITLE
Strategy pack options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   allowing these to be used when enumerating tracked trees.
 - Add the `InsertionEncodingVerificationStrategy` which verifies n x 1 and
   1 x n tilings which have a regular topmost or bottommost insertion encoding.
+- add partial flag to `insertion_point_placements` and
+  `insertion_row_and_col_placements`
+
+### Fixed
+- untracked fusion packs don't add assumption strategies
+- the length parameter for `all_the_strategies` is passed correctly to the
+  requirement insertion strategy.
 
 ## [2.0.0] - 2020-06-17
 ### Added

--- a/tests/test_strategy_pack.py
+++ b/tests/test_strategy_pack.py
@@ -37,10 +37,10 @@ def length(pack):
     return [pack(length=length) for length in (1, 2, 3)]
 
 
-def length_maxnumreq(pack):
+def length_maxnumreq_partial(pack):
     return [
-        pack(length=length, max_num_req=max_num_req)
-        for length, max_num_req in product((1, 2, 3), (1, 2, 3),)
+        pack(length=length, max_num_req=max_num_req, partial=partial)
+        for length, max_num_req, partial in product((1, 2, 3), (1, 2, 3), (True, False))
     ]
 
 
@@ -55,10 +55,6 @@ def directions(pack):
     return [pack(direction=direction) for direction in DIRS]
 
 
-def row_col(pack):
-    return [pack(), pack(row_only=True), pack(col_only=True)]
-
-
 def row_col_partial(pack):
     return [
         pack(row_only=row_only, col_only=col_only, partial=partial)
@@ -71,9 +67,9 @@ def row_col_partial(pack):
 
 packs = (
     length(TileScopePack.all_the_strategies)
-    + length(TileScopePack.insertion_point_placements)
-    + row_col(TileScopePack.insertion_row_and_col_placements)
-    + length_maxnumreq(TileScopePack.only_root_placements)
+    + length_partial(TileScopePack.insertion_point_placements)
+    + row_col_partial(TileScopePack.insertion_row_and_col_placements)
+    + length_maxnumreq_partial(TileScopePack.only_root_placements)
     + [
         TileScopePack.only_root_placements(
             length=3, max_num_req=2, max_placement_rules_per_req=100
@@ -92,6 +88,7 @@ packs.extend(
     + [pack.make_fusion() for pack in packs]
     + [pack.add_all_symmetry() for pack in packs]
     + [pack.make_database().add_all_symmetry() for pack in packs]
+    + [pack.make_fusion().add_all_symmetry() for pack in packs]
 )
 
 

--- a/tilings/strategy_pack.py
+++ b/tilings/strategy_pack.py
@@ -182,7 +182,7 @@ class TileScopePack(StrategyPack):
         name = "insertion_"
         if length > 1:
             name += "length_{}_".format(length)
-        partial_str = "partial" if partial else ""
+        partial_str = "partial_" if partial else ""
         name += f"{partial_str}point_placements"
         return TileScopePack(
             initial_strats=[

--- a/tilings/strategy_pack.py
+++ b/tilings/strategy_pack.py
@@ -45,11 +45,11 @@ class TileScopePack(StrategyPack):
             component and tracked
         ), "not implemented tracking for component fusion"
         pack = self
-        if strat.SplittingStrategy() not in self:
+        if tracked and strat.SplittingStrategy() not in self:
             pack = pack.add_initial(
                 strat.SplittingStrategy(ignore_parent=True), apply_first=True
             )
-        if strat.AddAssumptionFactory() not in self:
+        if tracked and strat.AddAssumptionFactory() not in self:
             pack = pack.add_initial(strat.AddAssumptionFactory(), apply_first=True)
         if component:
             pack = pack.add_initial(
@@ -94,7 +94,7 @@ class TileScopePack(StrategyPack):
     def all_the_strategies(cls, length: int = 1) -> "TileScopePack":
         return TileScopePack(
             initial_strats=[
-                strat.FactorFactory(unions=True),
+                strat.FactorFactory(unions=False),
                 strat.RequirementCorroborationFactory(),
             ],
             ver_strats=[
@@ -108,10 +108,7 @@ class TileScopePack(StrategyPack):
                 strat.ObstructionTransitivityFactory(),
             ],
             expansion_strats=[
-                [
-                    strat.CellInsertionFactory(maxreqlen=length),
-                    strat.RequirementInsertionFactory(),
-                ],
+                [strat.RequirementInsertionFactory(maxreqlen=length)],
                 [strat.AllPlacementsFactory()],
             ],
             name="all_the_strategies",
@@ -179,7 +176,9 @@ class TileScopePack(StrategyPack):
         )
 
     @classmethod
-    def insertion_point_placements(cls, length: int = 1) -> "TileScopePack":
+    def insertion_point_placements(
+        cls, length: int = 1, partial: bool = False
+    ) -> "TileScopePack":
         name = "insertion_"
         if length > 1:
             name += "length_{}_".format(length)
@@ -200,7 +199,7 @@ class TileScopePack(StrategyPack):
                 strat.RowColumnSeparationStrategy(),
                 strat.ObstructionTransitivityFactory(),
             ],
-            expansion_strats=[[strat.PatternPlacementFactory()]],
+            expansion_strats=[[strat.PatternPlacementFactory(partial=partial)]],
             name=name,
         )
 
@@ -276,9 +275,9 @@ class TileScopePack(StrategyPack):
 
     @classmethod
     def insertion_row_and_col_placements(
-        cls, row_only=False, col_only=False
+        cls, row_only: bool = False, col_only: bool = False, partial: bool = False
     ) -> "TileScopePack":
-        pack = cls.row_and_col_placements(row_only, col_only)
+        pack = cls.row_and_col_placements(row_only, col_only, partial)
         pack.name = "insertion_" + pack.name
         pack = pack.add_initial(
             strat.CellInsertionFactory(maxreqlen=1, ignore_parent=True)
@@ -291,13 +290,14 @@ class TileScopePack(StrategyPack):
         length: int = 3,
         max_num_req: Optional[int] = 1,
         max_placement_rules_per_req: Optional[int] = None,
+        partial: bool = False,
     ) -> "TileScopePack":
         if max_num_req is not None:
             name = f"only_length_{length}_{max_num_req}_reqs_root_placements"
         else:
             name = f"only_length_{length}_root_placements"
         placement_factory = strat.RequirementPlacementFactory(
-            max_rules_per_req=max_placement_rules_per_req
+            max_rules_per_req=max_placement_rules_per_req, partial=partial
         )
         return TileScopePack(
             initial_strats=[

--- a/tilings/strategy_pack.py
+++ b/tilings/strategy_pack.py
@@ -182,7 +182,8 @@ class TileScopePack(StrategyPack):
         name = "insertion_"
         if length > 1:
             name += "length_{}_".format(length)
-        name += "point_placements"
+        partial_str = "partial" if partial else ""
+        name += f"{partial_str}point_placements"
         return TileScopePack(
             initial_strats=[
                 strat.FactorFactory(),
@@ -292,10 +293,13 @@ class TileScopePack(StrategyPack):
         max_placement_rules_per_req: Optional[int] = None,
         partial: bool = False,
     ) -> "TileScopePack":
+        partial_str = "partial_" if partial else ""
         if max_num_req is not None:
-            name = f"only_length_{length}_{max_num_req}_reqs_root_placements"
+            name = (
+                f"only_length_{length}_{max_num_req}_reqs_root_{partial_str}placements"
+            )
         else:
-            name = f"only_length_{length}_root_placements"
+            name = f"only_length_{length}_root_{partial_str}placements"
         placement_factory = strat.RequirementPlacementFactory(
             max_rules_per_req=max_placement_rules_per_req, partial=partial
         )


### PR DESCRIPTION
### Added
- add partial flag to `insertion_point_placements` and
  `insertion_row_and_col_placements`

 ### Fixed
- untracked fusion packs don't add assumption strategies
- the length parameter for `all_the_strategies` is passed correctly to the
  requirement insertion strategy.