### PR TITLE
Symmetry fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - the length parameter for `all_the_strategies` is passed correctly to the
   requirement insertion strategy.
 - use fusion on positive `Av(123)` when expanding 1x1 verified classes
+- fix bug that prevented applying all eight symmetries
 
 ## [2.0.0] - 2020-06-17
 ### Added

--- a/tilings/strategies/assumption_insertion.py
+++ b/tilings/strategies/assumption_insertion.py
@@ -127,7 +127,7 @@ class AddAssumptionsStrategy(Strategy[Tiling, GriddedPerm]):
 
     def formal_step(self) -> str:
         if len(self.assumptions) == 1:
-            return f"adding the assumption '{self.assumptions[0]}"
+            return f"adding the assumption '{self.assumptions[0]}'"
         assumptions = ", ".join([f"'{ass}'" for ass in self.assumptions])
         return f"adding the assumptions '{assumptions}'"
 

--- a/tilings/strategies/symmetry.py
+++ b/tilings/strategies/symmetry.py
@@ -286,9 +286,10 @@ class SymmetriesFactory(StrategyFactory[Tiling]):
             if comb_class not in symmetries:
                 yield strategy(rotations, False)
             symmetries.add(comb_class)
-            if comb_class not in symmetries:
+            comb_class_inverse = comb_class.inverse()
+            if comb_class_inverse not in symmetries:
                 yield strategy(rotations, True)
-            symmetries.add(comb_class.inverse())
+            symmetries.add(comb_class_inverse)
             comb_class = comb_class.rotate90()
             if comb_class in symmetries:
                 break

--- a/tilings/strategies/symmetry.py
+++ b/tilings/strategies/symmetry.py
@@ -127,7 +127,7 @@ class TilingComplement(TilingSymmetryStrategy):
 
     @staticmethod
     def formal_step() -> str:
-        return "complement of the tiing"
+        return "complement of the tiling"
 
     def __str__(self) -> str:
         return "complement"


### PR DESCRIPTION
Fixes a bug that mean we were never computing all 8 symmetries, just 4 (the rotations). Also fixes a two minor typos I happened to spot.