### PR TITLE
refactor assumption mapping code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   turned off with the flag `tracked=False`.
 - `InsertionEncodingVerificationStrategy` was added to verification expansion
   packs.
+- `forward_map_assumption` method on `Tiling`.
 
 ### Changed
 - The definition of a local `TrackingAssumption` in `LocalEnumeration` now says

--- a/tilings/strategies/factor.py
+++ b/tilings/strategies/factor.py
@@ -60,7 +60,9 @@ class FactorStrategy(CartesianProductStrategy[Tiling, GriddedPerm]):
         ):
             for i, cells in enumerate(self.partition):
                 if assumption.gps[0].pos[0] in cells:
-                    new_assumption = children[i].forward_map_assumption(assumption)
+                    new_assumption = children[i].forward_map_assumption(
+                        assumption, check_avoidance=False
+                    )
                     child_var = children[i].get_parameter(new_assumption)
                     extra_parameters[i][parent_var] = child_var
                     break

--- a/tilings/strategies/factor.py
+++ b/tilings/strategies/factor.py
@@ -60,9 +60,7 @@ class FactorStrategy(CartesianProductStrategy[Tiling, GriddedPerm]):
         ):
             for i, cells in enumerate(self.partition):
                 if assumption.gps[0].pos[0] in cells:
-                    new_assumption = assumption.__class__(
-                        children[i].forward_map(gp) for gp in assumption.gps
-                    )
+                    new_assumption = children[i].forward_map_assumption(assumption)
                     child_var = children[i].get_parameter(new_assumption)
                     extra_parameters[i][parent_var] = child_var
                     break

--- a/tilings/strategies/fusion.py
+++ b/tilings/strategies/fusion.py
@@ -537,11 +537,7 @@ class FusionStrategy(Strategy[Tiling, GriddedPerm]):
         algo = self.fusion_algorithm(comb_class)
         child = children[0]
         mapped_assumptions = [
-            ass.__class__(
-                child.forward_map(gp)
-                for gp in gps
-                if all(cell in child.forward_cell_map for cell in gp.pos)
-            )
+            child.forward_map_assumption(ass.__class__(gps))
             for ass, gps in zip(comb_class.assumptions, algo.assumptions_fuse_counters)
         ]
         return (

--- a/tilings/strategies/fusion.py
+++ b/tilings/strategies/fusion.py
@@ -537,7 +537,11 @@ class FusionStrategy(Strategy[Tiling, GriddedPerm]):
         algo = self.fusion_algorithm(comb_class)
         child = children[0]
         mapped_assumptions = [
-            ass.__class__(child.forward_map(gp) for gp in gps)
+            ass.__class__(
+                child.forward_map(gp)
+                for gp in gps
+                if all(cell in child.forward_cell_map for cell in gp.pos)
+            )
             for ass, gps in zip(comb_class.assumptions, algo.assumptions_fuse_counters)
         ]
         return (

--- a/tilings/strategies/obstruction_inferral.py
+++ b/tilings/strategies/obstruction_inferral.py
@@ -45,25 +45,17 @@ class ObstructionInferralStrategy(DisjointUnionStrategy[Tiling, GriddedPerm]):
             children = self.decomposition_function(comb_class)
             if children is None:
                 raise StrategyDoesNotApply("Strategy does not apply")
-        av = children[0]
-        av_mapped_ass = [
-            ass.__class__(
-                tuple(
-                    av.forward_map(gp)
-                    for gp in ass.gps
-                    if gp.avoids(*self.gps)
-                    and all(cell in av.forward_cell_map for cell in gp.pos)
-                )
-            ).avoiding(av.obstructions)
-            for ass in comb_class.assumptions
-        ]
-        av_params: Dict[str, str] = {}
-        for assumption, mapped_assumption in zip(comb_class.assumptions, av_mapped_ass):
+        child = children[0]
+        params: Dict[str, str] = {}
+        for assumption in comb_class.assumptions:
+            mapped_assumption = child.forward_map_assumption(assumption).avoiding(
+                child.obstructions
+            )
             if mapped_assumption.gps:
                 parent_var = comb_class.get_parameter(assumption)
-                child_var = av.get_parameter(mapped_assumption)
-                av_params[parent_var] = child_var
-        return (av_params,)
+                child_var = child.get_parameter(mapped_assumption)
+                params[parent_var] = child_var
+        return (params,)
 
     def backward_map(
         self,

--- a/tilings/strategies/obstruction_inferral.py
+++ b/tilings/strategies/obstruction_inferral.py
@@ -48,9 +48,7 @@ class ObstructionInferralStrategy(DisjointUnionStrategy[Tiling, GriddedPerm]):
         child = children[0]
         params: Dict[str, str] = {}
         for assumption in comb_class.assumptions:
-            mapped_assumption = child.forward_map_assumption(assumption).avoiding(
-                child.obstructions
-            )
+            mapped_assumption = child.forward_map_assumption(assumption)
             if mapped_assumption.gps:
                 parent_var = comb_class.get_parameter(assumption)
                 child_var = child.get_parameter(mapped_assumption)

--- a/tilings/strategies/requirement_insertion.py
+++ b/tilings/strategies/requirement_insertion.py
@@ -84,18 +84,13 @@ class RequirementInsertionStrategy(DisjointUnionStrategy[Tiling, GriddedPerm]):
         av_params: Dict[str, str] = {}
         co_params: Dict[str, str] = {}
         for assumption in comb_class.assumptions:
-            av_mapped_assumption = av.forward_map_assumption(assumption).avoiding(
-                av.obstructions
-            )
+            parent_var = comb_class.get_parameter(assumption)
+            av_mapped_assumption = av.forward_map_assumption(assumption)
             if av_mapped_assumption.gps:
-                parent_var = comb_class.get_parameter(assumption)
                 child_var = av.get_parameter(av_mapped_assumption)
                 av_params[parent_var] = child_var
-            co_mapped_assumption = co.forward_map_assumption(assumption).avoiding(
-                co.obstructions
-            )
+            co_mapped_assumption = co.forward_map_assumption(assumption)
             if co_mapped_assumption.gps:
-                parent_var = comb_class.get_parameter(assumption)
                 child_var = co.get_parameter(co_mapped_assumption)
                 co_params[parent_var] = child_var
         return av_params, co_params

--- a/tilings/strategies/requirement_placement.py
+++ b/tilings/strategies/requirement_placement.py
@@ -89,7 +89,7 @@ class RequirementPlacementStrategy(DisjointUnionStrategy[Tiling, GriddedPerm]):
             zip(self._placed_cells, children[1:] if self.include_empty else children)
         ):
             mapped_assumptions = [
-                child.forward_map_assumption(ass).avoiding(child.obstructions)
+                child.forward_map_assumption(ass)
                 for ass in algo.stretched_assumptions(cell)
             ]
             for assumption, mapped_assumption in zip(

--- a/tilings/strategies/requirement_placement.py
+++ b/tilings/strategies/requirement_placement.py
@@ -77,18 +77,10 @@ class RequirementPlacementStrategy(DisjointUnionStrategy[Tiling, GriddedPerm]):
         extra_parameters: Tuple[Dict[str, str], ...] = tuple({} for _ in children)
         if self.include_empty:
             child = children[0]
-            mapped_assumptions = [
-                ass.__class__(
-                    child.forward_map(gp)
-                    for gp in ass.gps
-                    if all(cell in child.forward_cell_map for cell in gp.pos)
-                    and gp.avoids(*self.gps)
+            for assumption in comb_class.assumptions:
+                mapped_assumption = child.forward_map_assumption(assumption).avoiding(
+                    child.obstructions
                 )
-                for ass in comb_class.assumptions
-            ]
-            for assumption, mapped_assumption in zip(
-                comb_class.assumptions, mapped_assumptions
-            ):
                 if mapped_assumption.gps:
                     parent_var = comb_class.get_parameter(assumption)
                     child_var = child.get_parameter(mapped_assumption)
@@ -97,19 +89,7 @@ class RequirementPlacementStrategy(DisjointUnionStrategy[Tiling, GriddedPerm]):
             zip(self._placed_cells, children[1:] if self.include_empty else children)
         ):
             mapped_assumptions = [
-                ass.__class__(
-                    tuple(
-                        child.forward_map(gp)
-                        for gp in ass.gps
-                        if gp.avoids(
-                            *algo.stretched_obstructions(cell),
-                            *algo.forced_obstructions_from_requirement(
-                                self.gps, self.indices, cell, self.direction
-                            ),
-                        )
-                        and all(cell in child.forward_cell_map for cell in gp.pos)
-                    )
-                ).avoiding(child.obstructions)
+                child.forward_map_assumption(ass).avoiding(child.obstructions)
                 for ass in algo.stretched_assumptions(cell)
             ]
             for assumption, mapped_assumption in zip(

--- a/tilings/strategies/symmetry.py
+++ b/tilings/strategies/symmetry.py
@@ -47,9 +47,7 @@ class TilingSymmetryStrategy(SymmetryStrategy[Tiling, GriddedPerm]):
                 raise StrategyDoesNotApply("Strategy does not apply")
         child = children[0]
         mapped_assumptions = tuple(
-            ass.__class__(
-                tuple(self.gp_transform(comb_class, gp) for gp in ass.gps)
-            ).avoiding(child.obstructions)
+            ass.__class__(tuple(self.gp_transform(comb_class, gp) for gp in ass.gps))
             for ass in comb_class.assumptions
         )
         return (

--- a/tilings/tiling.py
+++ b/tilings/tiling.py
@@ -781,15 +781,24 @@ class Tiling(CombinatorialClass):
         return GriddedPerm(gp.patt, [self.forward_cell_map[cell] for cell in gp.pos])
 
     def forward_map_assumption(
-        self, assumption: TrackingAssumption
+        self, assumption: TrackingAssumption, check_avoidance: bool = True
     ) -> TrackingAssumption:
-        return assumption.__class__(
+        """
+        Maps the assumption using the `forward_map` method on each gridded perm.
+
+        If check_avoidance, it will return the assumption with only the mapped
+        gridded perms that avoid the obstructions on the tiling.
+        """
+        mapped_assumption = assumption.__class__(
             tuple(
                 self.forward_map(gp)
                 for gp in assumption.gps
                 if all(cell in self.forward_cell_map for cell in gp.pos)
             )
-        ).avoiding(self.obstructions)
+        )
+        if check_avoidance:
+            return mapped_assumption.avoiding(self.obstructions)
+        return mapped_assumption
 
     @property
     def forward_cell_map(self) -> CellMap:

--- a/tilings/tiling.py
+++ b/tilings/tiling.py
@@ -780,6 +780,17 @@ class Tiling(CombinatorialClass):
     def forward_map(self, gp: GriddedPerm) -> GriddedPerm:
         return GriddedPerm(gp.patt, [self.forward_cell_map[cell] for cell in gp.pos])
 
+    def forward_map_assumption(
+        self, assumption: TrackingAssumption
+    ) -> TrackingAssumption:
+        return assumption.__class__(
+            tuple(
+                self.forward_map(gp)
+                for gp in assumption.gps
+                if all(cell in self.forward_cell_map for cell in gp.pos)
+            )
+        ).avoiding(self.obstructions)
+
     @property
     def forward_cell_map(self) -> CellMap:
         try:


### PR DESCRIPTION
This fixes #201 

Before merging, to avoid errors down the line, we should create a method `forward_map_assumption` on `Tiling` as this particular snippet is the same in several strategies (e.g., req insertion) and apparently every time I need it, I forget this tiny detail!