### PR TITLE
Component tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - introduced isolation levels to the fusion strategy
 - added the `one_cell_only` option to `CellInsertionFactory`
+- `remove_components_from_assumptions` method to `Tiling`
+- `DetectComponentsStrategy` which removes cells from assumptions
+   which are actual components. This replaces the need for the
+   `SplittingStrategy` in component fusion packs.
 
 ### Changed
 - insertion packs now use the `one_cell_only` option, and no longer use
   `RequirementCorroborationFactory`
+- forbid fusing a region containing a `TrackingAssumption` and a
+  `ComponentAssumption`
+- a tiling factors if a `ComponentAssumption` if the components of the region
+  split into the factors
 
 ## [2.2.0] - 2020-07-08
 ### Added

--- a/tests/test_tilescope.py
+++ b/tests/test_tilescope.py
@@ -294,3 +294,39 @@ def test_single_fusion_db():
     assert isinstance(spec, CombinatorialSpecification)
     expected_enum = [1, 1, 2, 6, 22, 90, 394, 1806, 8558, 41586, 206098]
     assert [spec.count_objects_of_size(n) for n in range(11)] == expected_enum
+
+
+@pytest.mark.timeout(30)
+def test_domino():
+    domino = Tiling(
+        obstructions=[
+            GriddedPerm(Perm((0, 2, 1)), [(0, 0), (0, 0), (0, 0)]),
+            GriddedPerm(Perm((1, 0, 2)), [(0, 1), (0, 1), (0, 1)]),
+            GriddedPerm(Perm((0, 2, 1, 3)), [(0, 0), (0, 1), (0, 0), (0, 1)]),
+        ]
+    )
+    tilescope = TileScope(
+        domino,
+        TileScopePack.row_and_col_placements().make_fusion(
+            tracked=True, component=True
+        ),
+    )
+    spec = tilescope.auto_search()
+    assert isinstance(spec, CombinatorialSpecification)
+    assert [spec.count_objects_of_size(i) for i in range(15)] == [
+        1,
+        2,
+        6,
+        22,
+        91,
+        408,
+        1938,
+        9614,
+        49335,
+        260130,
+        1402440,
+        7702632,
+        42975796,
+        243035536,
+        1390594458,
+    ]

--- a/tilings/algorithms/factor.py
+++ b/tilings/algorithms/factor.py
@@ -75,7 +75,8 @@ class Factor:
         """
         for assumption in self._tiling.assumptions:
             if isinstance(assumption, ComponentAssumption):
-                self._unite_cells(chain.from_iterable(gp.pos for gp in assumption.gps))
+                for comp in assumption.get_components(self._tiling):
+                    self._unite_cells(chain.from_iterable(gp.pos for gp in comp))
             else:
                 for gp in assumption.gps:
                     self._unite_cells(gp.pos)
@@ -188,7 +189,10 @@ class Factor:
         """
         return tuple(
             self._tiling.__class__(
-                obstructions=f[0], requirements=f[1], assumptions=f[2], simplify=False
+                obstructions=f[0],
+                requirements=f[1],
+                assumptions=tuple(sorted(f[2])),
+                simplify=False,
             )
             for f in self._get_factors_obs_and_reqs()
         )
@@ -212,7 +216,7 @@ class Factor:
                     self._tiling.__class__(
                         obstructions=chain(*obstructions),
                         requirements=chain(*requirements),
-                        assumptions=chain(*assumptions),
+                        assumptions=tuple(sorted(chain(*assumptions))),
                         simplify=False,
                     )
                 )

--- a/tilings/algorithms/fusion.py
+++ b/tilings/algorithms/fusion.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Optional
 
 from permuta import Perm
 from tilings.assumptions import (
+    ComponentAssumption,
     SkewComponentAssumption,
     SumComponentAssumption,
     TrackingAssumption,
@@ -251,6 +252,10 @@ class Fusion:
         are all contained entirely on the left of the fusion region, entirely
         on the right, or split in every possible way.
         """
+        if isinstance(assumption, ComponentAssumption):
+            return self.is_left_sided_assumption(
+                assumption
+            ) and self.is_right_sided_assumption(assumption)
         return self._can_fuse_set_of_gridded_perms(fuse_counter) or (
             all(count == 1 for gp, count in fuse_counter.items())
             and self._is_one_sided_assumption(assumption)
@@ -531,6 +536,21 @@ class ComponentFusion(Fusion):
         """
         return chain.from_iterable(
             self._unfuse_gridded_perm(ob) for ob in self.obstruction_fuse_counter
+        )
+
+    def _can_fuse_assumption(self, assumption, fuse_counter):
+        """
+        Return True if an assumption can be fused. That is, prefusion, the gps
+        are all contained entirely on the left of the fusion region, entirely
+        on the right, or split in every possible way.
+        """
+        if not isinstance(assumption, ComponentAssumption):
+            return self.is_left_sided_assumption(
+                assumption
+            ) and self.is_right_sided_assumption(assumption)
+        return self._can_fuse_set_of_gridded_perms(fuse_counter) or (
+            all(count == 1 for gp, count in fuse_counter.items())
+            and self._is_one_sided_assumption(assumption)
         )
 
     def _can_fuse_set_of_gridded_perms(self, fuse_counter):

--- a/tilings/assumptions.py
+++ b/tilings/assumptions.py
@@ -1,7 +1,7 @@
 import abc
 from importlib import import_module
 from itertools import chain
-from typing import Iterable, List, Optional, Set, Tuple, Type, TYPE_CHECKING
+from typing import TYPE_CHECKING, FrozenSet, Iterable, List, Optional, Tuple, Type
 
 from permuta import Perm
 
@@ -141,7 +141,10 @@ class ComponentAssumption(TrackingAssumption):
 
     @abc.abstractmethod
     def is_component(
-        self, cells: List[Cell], point_cells: Set[Cell], positive_cells: Set[Cell]
+        self,
+        cells: List[Cell],
+        point_cells: FrozenSet[Cell],
+        positive_cells: FrozenSet[Cell],
     ) -> bool:
         """
         Return True if cells form a component.
@@ -196,7 +199,7 @@ class SumComponentAssumption(ComponentAssumption):
 
     @staticmethod
     def is_component(
-        cells: List[Cell], point_cells: Set[Cell], positive_cells: Set[Cell]
+        cells: List[Cell], point_cells: FrozenSet[Cell], positive_cells: FrozenSet[Cell]
     ) -> bool:
         if len(cells) == 2:
             (x1, y1), (x2, y2) = sorted(cells)
@@ -224,7 +227,7 @@ class SkewComponentAssumption(ComponentAssumption):
 
     @staticmethod
     def is_component(
-        cells: List[Cell], point_cells: Set[Cell], positive_cells: Set[Cell]
+        cells: List[Cell], point_cells: FrozenSet[Cell], positive_cells: FrozenSet[Cell]
     ) -> bool:
         if len(cells) == 2:
             (x1, y1), (x2, y2) = sorted(cells)

--- a/tilings/strategies/__init__.py
+++ b/tilings/strategies/__init__.py
@@ -1,5 +1,6 @@
 from .assumption_insertion import AddAssumptionFactory, AddInterleavingAssumptionFactory
 from .assumption_splitting import SplittingStrategy
+from .detect_components import DetectComponentsStrategy
 from .factor import FactorFactory
 from .fusion import ComponentFusionFactory, FusionFactory
 from .obstruction_inferral import (
@@ -39,6 +40,7 @@ __all__ = [
     # Assumptions
     "AddAssumptionFactory",
     "AddInterleavingAssumptionFactory",
+    "DetectComponentsStrategy",
     "SplittingStrategy",
     # Batch
     "CellInsertionFactory",

--- a/tilings/strategies/detect_components.py
+++ b/tilings/strategies/detect_components.py
@@ -1,0 +1,123 @@
+from typing import Dict, Iterator, Optional, Tuple
+
+from comb_spec_searcher import (
+    Constructor,
+    Strategy,
+)
+from comb_spec_searcher.exception import StrategyDoesNotApply
+from comb_spec_searcher.strategies.constructor import (
+    RelianceProfile,
+    SubGens,
+    SubRecs,
+    SubSamplers,
+)
+from sympy import Eq, Function
+from tilings import GriddedPerm, Tiling, TrackingAssumption
+
+
+class CountComponent(Constructor[Tiling, GriddedPerm]):
+    """
+    The constructor used to count when we see actual components.
+
+    The components dictionary counts how many components are to be counted by
+    each parameter, noting they will no longer be tracked in the child.
+
+    The extra_parameters map the parent constructor to the child parameter. If
+    a parent parameter became empty by removing a component, then it will not
+    the parent parameter will not be a key in extra_parameters.
+    """
+
+    def __init__(self, components: Dict[str, int], extra_parameters: Dict[str, str]):
+        self.components = components
+        self.extra_parameters = extra_parameters
+
+    def get_equation(self, lhs_func: Function, rhs_funcs: Tuple[Function, ...]) -> Eq:
+        raise NotImplementedError
+
+    def reliance_profile(self, n: int, **parameters: int) -> RelianceProfile:
+        raise NotImplementedError
+
+    def get_recurrence(self, subrecs: SubRecs, n: int, **parameters: int) -> int:
+        raise NotImplementedError
+
+    def get_sub_objects(
+        self, subgens: SubGens, n: int, **parameters: int
+    ) -> Iterator[Tuple[GriddedPerm, ...]]:
+        raise NotImplementedError
+
+    def random_sample_sub_objects(
+        self,
+        parent_count: int,
+        subsamplers: SubSamplers,
+        subrecs: SubRecs,
+        n: int,
+        **parameters: int,
+    ):
+        raise NotImplementedError
+
+    @staticmethod
+    def get_eq_symbol() -> str:
+        return "↣"
+
+
+class DetectComponentsStrategy(Strategy[Tiling, GriddedPerm]):
+    @staticmethod
+    def can_be_equivalent() -> bool:
+        return False
+
+    def decomposition_function(self, tiling: Tiling) -> Optional[Tuple[Tiling]]:
+        if not tiling.assumptions:
+            return None
+        return (tiling.remove_components_from_assumptions(),)
+
+    def constructor(
+        self, comb_class: Tiling, children: Optional[Tuple[Tiling, ...]] = None,
+    ) -> CountComponent:
+        if children is None:
+            children = self.decomposition_function(comb_class)
+            if children is None:
+                raise StrategyDoesNotApply("Can't split the tracking assumption")
+
+        removed_components: Dict[str, int] = {}
+        for ass in comb_class.assumptions:
+            value = len(ass.get_components(comb_class))
+            if value:
+                k = comb_class.get_parameter(ass)
+                removed_components[k] = value
+        return CountComponent(removed_components, {})
+
+    @staticmethod
+    def formal_step() -> str:
+        return "removing exact components"
+
+    def backward_map(
+        self,
+        comb_class: Tiling,
+        objs: Tuple[Optional[GriddedPerm], ...],
+        children: Optional[Tuple[Tiling, ...]] = None,
+    ) -> GriddedPerm:
+        """
+        The forward direction of the underlying bijection used for object
+        generation and sampling.
+        """
+        if children is None:
+            children = self.decomposition_function(comb_class)
+        raise NotImplementedError
+
+    def forward_map(
+        self,
+        comb_class: Tiling,
+        obj: GriddedPerm,
+        children: Optional[Tuple[Tiling, ...]] = None,
+    ) -> Tuple[Optional[GriddedPerm], ...]:
+        """
+        The backward direction of the underlying bijection used for object
+        generation and sampling.
+        """
+        if children is None:
+            children = self.decomposition_function(comb_class)
+        raise NotImplementedError
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "DetectComponentsStrategy":
+        return cls(**d)

--- a/tilings/strategies/detect_components.py
+++ b/tilings/strategies/detect_components.py
@@ -22,9 +22,9 @@ class CountComponent(Constructor[Tiling, GriddedPerm]):
     The components dictionary counts how many components are to be counted by
     each parameter, noting they will no longer be tracked in the child.
 
-    The extra_parameters map the parent constructor to the child parameter. If
-    a parent parameter became empty by removing a component, then it will not
-    the parent parameter will not be a key in extra_parameters.
+    The extra_parameters map the parent parameters to the child parameters. If
+    a parent parameter became empty by removing a component the parent
+    parameter will not be a key in extra_parameters.
     """
 
     def __init__(self, components: Dict[str, int], extra_parameters: Dict[str, str]):
@@ -94,7 +94,7 @@ class DetectComponentsStrategy(Strategy[Tiling, GriddedPerm]):
         if children is None:
             children = self.decomposition_function(comb_class)
             if children is None:
-                raise StrategyDoesNotApply("Can't split the tracking assumption")
+                raise StrategyDoesNotApply("Can't detect components")
 
         removed_components: Dict[str, int] = {}
         for ass in comb_class.assumptions:

--- a/tilings/strategies/detect_components.py
+++ b/tilings/strategies/detect_components.py
@@ -2,10 +2,9 @@ from functools import reduce
 from operator import mul
 from typing import Dict, Iterator, Optional, Tuple
 
-from comb_spec_searcher import (
-    Constructor,
-    Strategy,
-)
+from sympy import Eq, Function, var
+
+from comb_spec_searcher import Constructor, Strategy
 from comb_spec_searcher.exception import StrategyDoesNotApply
 from comb_spec_searcher.strategies.constructor import (
     RelianceProfile,
@@ -13,8 +12,7 @@ from comb_spec_searcher.strategies.constructor import (
     SubRecs,
     SubSamplers,
 )
-from sympy import var, Eq, Function
-from tilings import GriddedPerm, Tiling, TrackingAssumption
+from tilings import GriddedPerm, Tiling
 
 
 class CountComponent(Constructor[Tiling, GriddedPerm]):
@@ -56,8 +54,7 @@ class CountComponent(Constructor[Tiling, GriddedPerm]):
             if mapped_k is not None:
                 if mapped_k in new_params and new_params[mapped_k] != val:
                     return 0
-                else:
-                    new_params[mapped_k] = val
+                new_params[mapped_k] = val
         return subrecs[0](n, **new_params)
 
     def get_sub_objects(
@@ -85,7 +82,8 @@ class DetectComponentsStrategy(Strategy[Tiling, GriddedPerm]):
     def can_be_equivalent() -> bool:
         return False
 
-    def decomposition_function(self, tiling: Tiling) -> Optional[Tuple[Tiling]]:
+    @staticmethod
+    def decomposition_function(tiling: Tiling) -> Optional[Tuple[Tiling]]:
         if not tiling.assumptions:
             return None
         return (tiling.remove_components_from_assumptions(),)
@@ -129,8 +127,8 @@ class DetectComponentsStrategy(Strategy[Tiling, GriddedPerm]):
     def formal_step() -> str:
         return "removing exact components"
 
+    @staticmethod
     def backward_map(
-        self,
         comb_class: Tiling,
         objs: Tuple[Optional[GriddedPerm], ...],
         children: Optional[Tuple[Tiling, ...]] = None,
@@ -139,12 +137,11 @@ class DetectComponentsStrategy(Strategy[Tiling, GriddedPerm]):
         The forward direction of the underlying bijection used for object
         generation and sampling.
         """
-        if children is None:
-            children = self.decomposition_function(comb_class)
-        raise NotImplementedError
+        assert isinstance(objs[0], GriddedPerm)
+        return objs[0]
 
+    @staticmethod
     def forward_map(
-        self,
         comb_class: Tiling,
         obj: GriddedPerm,
         children: Optional[Tuple[Tiling, ...]] = None,
@@ -153,9 +150,7 @@ class DetectComponentsStrategy(Strategy[Tiling, GriddedPerm]):
         The backward direction of the underlying bijection used for object
         generation and sampling.
         """
-        if children is None:
-            children = self.decomposition_function(comb_class)
-        raise NotImplementedError
+        return (obj,)
 
     @classmethod
     def from_dict(cls, d: dict) -> "DetectComponentsStrategy":

--- a/tilings/strategy_pack.py
+++ b/tilings/strategy_pack.py
@@ -64,7 +64,7 @@ class TileScopePack(StrategyPack):
             pack = pack.make_tracked()
             if component:
                 pack = pack.add_initial(
-                    strat.SplittingStrategy(ignore_parent=True), apply_first=True
+                    strat.DetectComponentsStrategy(ignore_parent=True), apply_first=True
                 )
         if component:
             pack = pack.add_initial(

--- a/tilings/tiling.py
+++ b/tilings/tiling.py
@@ -621,6 +621,20 @@ class Tiling(CombinatorialClass):
             sorted_input=True,
         )
 
+    def remove_components_from_assumptions(self):
+        """
+        Return the tiling with all the actual components from individual
+        assumptions removed.
+        """
+        if not self.assumptions:
+            return self
+        assumptions = [ass.remove_components(self) for ass in self.assumptions]
+        return self.__class__(
+            self._obstructions,
+            self._requirements,
+            [ass for ass in assumptions if ass.gps],
+        )
+
     def fully_isolated(self) -> bool:
         """Check if all cells are isolated on their rows and columns."""
         seen_row: List[int] = []
@@ -1004,7 +1018,7 @@ class Tiling(CombinatorialClass):
         return self.__class__(
             obstructions,
             requirements,
-            set(ass for ass in assumptions if ass.gps),
+            tuple(sorted(set(ass for ass in assumptions if ass.gps))),
             simplify=False,
             sorted_input=True,
         )
@@ -1040,6 +1054,12 @@ class Tiling(CombinatorialClass):
         """
         rcs = RowColSeparation(self)
         return rcs.separated_tiling()
+
+    def row_and_column_separation_with_mapping(
+        self,
+    ) -> Tuple["Tiling", Dict[Cell, Cell]]:
+        rcs = RowColSeparation(self)
+        return rcs.separated_tiling(), rcs.get_cell_map()
 
     def obstruction_transitivity(self) -> "Tiling":
         """


### PR DESCRIPTION
### Added
- `remove_components_from_assumptions` method to `Tiling`
- `DetectComponentsStrategy` which removes cells from assumptions
   which are actual components. This replaces the need for the
   `SplittingStrategy` in component fusion packs.

### Changed
- forbid fusing a region containing a `TrackingAssumption` and a
  `ComponentAssumption`
- a tiling factors if a `ComponentAssumption` if the components of the region
  split into the factors