### PR TITLE
pylint fixes in tiling.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - the method `Tiling.get_genf` returns the Catalan generating function for Av(123).
 - correct the generating function equations for `SplittingStrategy`
 
+### Removed
+- Removed optional arguments from the `from_bytes` method on `Tiling`
+
 ## [2.1.0] - 2020-06-29
 ### Added
 - add a new `AddAssumptionStrategy` which adds an assumption to a tiling.

--- a/tests/test_tiling.py
+++ b/tests/test_tiling.py
@@ -417,9 +417,7 @@ def test_bytes_noreq(typical_redundant_obstructions):
         derive_empty=False,
     )
 
-    assert tiling == Tiling.from_bytes(
-        tiling.to_bytes(), remove_empty_rows_and_cols=False, derive_empty=False
-    )
+    assert tiling == Tiling.from_bytes(tiling.to_bytes())
 
     tiling = Tiling(
         obstructions=typical_redundant_obstructions,
@@ -427,18 +425,14 @@ def test_bytes_noreq(typical_redundant_obstructions):
         derive_empty=True,
     )
 
-    assert tiling == Tiling.from_bytes(
-        tiling.to_bytes(), remove_empty_rows_and_cols=False, derive_empty=True
-    )
+    assert tiling == Tiling.from_bytes(tiling.to_bytes())
 
     tiling = Tiling(
         obstructions=typical_redundant_obstructions,
         remove_empty_rows_and_cols=True,
         derive_empty=True,
     )
-    assert tiling == Tiling.from_bytes(
-        tiling.to_bytes(), remove_empty_rows_and_cols=True, derive_empty=True
-    )
+    assert tiling == Tiling.from_bytes(tiling.to_bytes())
 
 
 def test_from_string():

--- a/tilings/tiling.py
+++ b/tilings/tiling.py
@@ -1,9 +1,4 @@
-# pylint: disable=too-many-locals
 # pylint: disable=too-many-lines
-# pylint: disable=too-many-branches
-# pylint: disable=arguments-differ
-# pylint: disable=too-many-statements
-# pylint: disable=import-outside-toplevel
 import json
 from array import array
 from collections import Counter, defaultdict
@@ -395,16 +390,10 @@ class Tiling(CombinatorialClass):
         return res.tobytes()
 
     @classmethod
-    def from_bytes(
-        cls,
-        arrbytes: bytes,
-        remove_empty_rows_and_cols=False,
-        derive_empty=False,
-        simplify=False,
-        sorted_input=True,
-    ) -> "Tiling":
+    def from_bytes(cls, b: bytes, **kwargs) -> "Tiling":
         """Given a compressed tiling in the form of an 1-byte array, decompress
         it and return a tiling."""
+        # pylint: disable=too-many-locals
 
         def merge_8bit(lh, uh):
             """
@@ -429,7 +418,7 @@ class Tiling(CombinatorialClass):
                 offset += 3 * pattlen
             return res, offset
 
-        arr = array("B", arrbytes)
+        arr = array("B", b)
         obstructions, offset = recreate_gp_list(0)
 
         nreqs = merge_8bit(arr[offset], arr[offset + 1])
@@ -462,10 +451,10 @@ class Tiling(CombinatorialClass):
             obstructions=obstructions,
             requirements=requirements,
             assumptions=assumptions,
-            remove_empty_rows_and_cols=remove_empty_rows_and_cols,
-            derive_empty=derive_empty,
-            simplify=simplify,
-            sorted_input=sorted_input,
+            remove_empty_rows_and_cols=kwargs.get("remove_empty_rows_and_cols", False),
+            derive_empty=kwargs.get("derive_empty", False),
+            simplify=kwargs.get("simplify", False),
+            sorted_input=kwargs.get("sorted_input", True),
         )
 
     @classmethod
@@ -499,14 +488,12 @@ class Tiling(CombinatorialClass):
         return cls.from_dict(jsondict)
 
     @classmethod
-    def from_dict(cls, jsondict: dict) -> "Tiling":
+    def from_dict(cls, d: dict) -> "Tiling":
         """Returns a Tiling object from a dictionary loaded from a JSON
         serialized Tiling object."""
-        obstructions = map(GriddedPerm.from_dict, jsondict["obstructions"])
-        requirements = map(
-            lambda x: map(GriddedPerm.from_dict, x), jsondict["requirements"]
-        )
-        assumptions = map(TrackingAssumption.from_dict, jsondict["assumptions"])
+        obstructions = map(GriddedPerm.from_dict, d["obstructions"])
+        requirements = map(lambda x: map(GriddedPerm.from_dict, x), d["requirements"])
+        assumptions = map(TrackingAssumption.from_dict, d["assumptions"])
         return cls(
             obstructions=obstructions,
             requirements=requirements,
@@ -1486,6 +1473,7 @@ class Tiling(CombinatorialClass):
         )
 
     def get_genf(self, *args, **kwargs) -> sympy.Expr:
+        # pylint: disable=import-outside-toplevel
         if self.is_empty():
             return sympy.sympify(0)
         from .strategies import (
@@ -1555,6 +1543,9 @@ class Tiling(CombinatorialClass):
         )
 
     def __str__(self) -> str:
+        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-branches
+        # pylint: disable=too-many-statements
         dim_i, dim_j = self.dimensions
         result = []
         # Create tiling lines

--- a/tilings/tiling.py
+++ b/tilings/tiling.py
@@ -390,7 +390,7 @@ class Tiling(CombinatorialClass):
         return res.tobytes()
 
     @classmethod
-    def from_bytes(cls, b: bytes, **kwargs) -> "Tiling":
+    def from_bytes(cls, b: bytes) -> "Tiling":
         """Given a compressed tiling in the form of an 1-byte array, decompress
         it and return a tiling."""
         # pylint: disable=too-many-locals
@@ -451,10 +451,10 @@ class Tiling(CombinatorialClass):
             obstructions=obstructions,
             requirements=requirements,
             assumptions=assumptions,
-            remove_empty_rows_and_cols=kwargs.get("remove_empty_rows_and_cols", False),
-            derive_empty=kwargs.get("derive_empty", False),
-            simplify=kwargs.get("simplify", False),
-            sorted_input=kwargs.get("sorted_input", True),
+            remove_empty_rows_and_cols=False,
+            derive_empty=False,
+            simplify=False,
+            sorted_input=True,
         )
 
     @classmethod


### PR DESCRIPTION
Removes some pylint errors, and moves failures to local to the function which have them. 

This is in response to issue #144 