### PR TITLE
Update to CSS 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - insertion packs now use the `one_cell_only` option, and no longer use
   `RequirementCorroborationFactory`
+- the `get_eq_symbol` and `get_op_symbol` are moved to `Strategy` rather than
+  `Constructor`
+
+### Fixed
+- untracked constructors raise `NotImplementedError`
 
 ## [2.2.0] - 2020-07-08
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -295,6 +295,59 @@ done here for sake of brevity in this readme!
        >>> import logzero; import logging; logzero.loglevel(logging.CRITICAL)
        >>> spec = tilescope.auto_search()
        >>> print(spec)
+       A combinatorial specification with 4 rules.
+       -----------
+       0 -> (1, 2)
+       insert 0 in cell (0, 0)
+       +-+            +-+     +-+
+       |1|         =  | |  +  |1|
+       +-+            +-+     +-+
+       1: Av(120)             1: Av+(120)
+                              Requirement 0:
+                              0: (0, 0)
+       -------
+       1 -> ()
+       is atom
+       +-+
+       | |
+       +-+
+       <BLANKLINE>
+       -----
+       2 = 3
+       placing the topmost point in cell (0, 0), then row and column separation
+       +-+                +-+-+-+                    +-+-+-+
+       |1|             =  | |●| |                 =  | |●| |
+       +-+                +-+-+-+                    +-+-+-+
+       1: Av+(120)        |1| |1|                    | | |1|
+       Requirement 0:     +-+-+-+                    +-+-+-+
+       0: (0, 0)          1: Av(120)                 |1| | |
+                          ●: point                   +-+-+-+
+                          Crossing obstructions:     1: Av(120)
+                          10: (0, 0), (2, 0)         ●: point
+                          Requirement 0:             Requirement 0:
+                          0: (1, 1)                  0: (1, 2)
+       -------
+       3 -> ()
+       tiling is locally factorable
+       +-+-+-+
+       | |●| |
+       +-+-+-+
+       | | |1|
+       +-+-+-+
+       |1| | |
+       +-+-+-+
+       1: Av(120)
+       ●: point
+       Requirement 0:
+       0: (1, 2)
+
+The locally factorable tiling in the rule `3 -> ()` could be further expanded
+down to atoms. This can be done using the `expand_verified` method.
+
+.. code:: python
+
+       >>> spec.expand_verified()
+       >>> print(spec)
        A combinatorial specification with 5 rules.
        -----------
        0 -> (1, 2)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(),
     long_description=read("README.rst"),
     install_requires=[
-        "comb-spec-searcher==1.3.0",
+        "comb-spec-searcher==2.0.0",
         "permuta==1.5.0",
         "requests==2.24.0",
         "typing-extensions==3.7.4.2",

--- a/tests/strategies/test_factors.py
+++ b/tests/strategies/test_factors.py
@@ -1,10 +1,12 @@
+from itertools import chain
+
 import pytest
 
 from comb_spec_searcher import CartesianProduct
 from permuta import Perm
 from tilings import GriddedPerm, Tiling
 from tilings.strategies import FactorFactory
-from tilings.strategies.factor import Interleaving, MonotoneInterleaving
+from tilings.strategies.factor import Interleaving
 
 pytest_plugins = [
     "tests.fixtures.simple_tiling",
@@ -176,13 +178,9 @@ def test_formal_step(factor_rules, factor_with_int_rules, factor_with_mon_int_ru
 
 def test_constructor(factor_rules, factor_with_int_rules, factor_with_mon_int_rules):
     assert all(rule.constructor.__class__ == CartesianProduct for rule in factor_rules)
-    assert all(
-        rule.constructor.__class__ == Interleaving for rule in factor_with_int_rules
-    )
-    assert all(
-        rule.constructor.__class__ == MonotoneInterleaving
-        for rule in factor_with_mon_int_rules
-    )
+    for rule in chain(factor_with_int_rules, factor_with_mon_int_rules):
+        with pytest.raises(NotImplementedError):
+            assert isinstance(rule.constructor, Interleaving)
 
 
 def test_rule(

--- a/tests/strategies/test_fusion_strat.py
+++ b/tests/strategies/test_fusion_strat.py
@@ -127,12 +127,12 @@ def test_fusion(small_tiling, big_tiling):
 
 @pytest.fixture
 def row_fusion(small_tiling):
-    return FusionStrategy(row_idx=0)(small_tiling)
+    return FusionStrategy(row_idx=0, tracked=True)(small_tiling)
 
 
 @pytest.fixture
 def col_fusion(small_tiling):
-    return FusionStrategy(col_idx=0)(small_tiling)
+    return FusionStrategy(col_idx=0, tracked=True)(small_tiling)
 
 
 def test_formal_step_fusion(row_fusion, col_fusion):
@@ -143,7 +143,7 @@ def test_formal_step_fusion(row_fusion, col_fusion):
 def test_rule(row_fusion):
     assert row_fusion.formal_step == "fuse rows 0 and 1"
     assert list(row_fusion.children) == [
-        Fusion(row_fusion.comb_class, row_idx=0).fused_tiling()
+        Fusion(row_fusion.comb_class, row_idx=0, tracked=True).fused_tiling()
     ]
     assert row_fusion.inferrable
     assert row_fusion.workable
@@ -183,12 +183,12 @@ def col_tiling():
 
 @pytest.fixture
 def component_row_fusion(row_tiling):
-    return ComponentFusionStrategy(row_idx=0)(row_tiling)
+    return ComponentFusionStrategy(row_idx=0, tracked=True)(row_tiling)
 
 
 @pytest.fixture
 def component_col_fusion(col_tiling):
-    return ComponentFusionStrategy(col_idx=0)(col_tiling)
+    return ComponentFusionStrategy(col_idx=0, tracked=True)(col_tiling)
 
 
 def test_formal_step_component(component_col_fusion, component_row_fusion):

--- a/tests/test_assumptions.py
+++ b/tests/test_assumptions.py
@@ -114,6 +114,7 @@ def test_123_fusion():
     pack = TileScopePack.row_and_col_placements(row_only=True).make_fusion(tracked=True)
     css = TileScope("123", pack)
     spec = css.auto_search(status_update=30)
+    spec.expand_verified()
     assert isinstance(spec, CombinatorialSpecification)
     assert [spec.count_objects_of_size(i) for i in range(20)] == [
         1,
@@ -146,6 +147,8 @@ def test_123_positive_fusions():
     )
     css = TileScope("123", pack)
     spec = css.auto_search(status_update=30)
+    spec.expand_verified()
+    print(spec)
     assert isinstance(spec, CombinatorialSpecification)
     assert [spec.count_objects_of_size(i) for i in range(20)] == [
         1,
@@ -176,6 +179,7 @@ def test_123_interleaving():
     pack = TileScopePack.point_placements().make_interleaving()
     css = TileScope("123", pack)
     spec = css.auto_search(status_update=30)
+    spec.expand_verified()
     assert isinstance(spec, CombinatorialSpecification)
     assert [spec.count_objects_of_size(i) for i in range(20)] == [
         1,

--- a/tests/test_tilescope.py
+++ b/tests/test_tilescope.py
@@ -68,6 +68,8 @@ def test_132_genf():
 def test_132_elementary():
     searcher = TileScope(Tiling.from_string("132"), point_placements.make_elementary())
     spec = searcher.auto_search()
+    assert spec.number_of_rules() == 4
+    spec.expand_verified()
     assert spec.number_of_rules() == 5
     assert isinstance(spec, CombinatorialSpecification)
 
@@ -271,6 +273,7 @@ def test_expansion():
     pack = TileScopePack.only_root_placements(3, 1)
     css = TileScope("132", pack)
     spec = css.auto_search(smallest=True)
+    spec.expand_verified()
     for comb_class, rule in spec.rules_dict.items():
         if isinstance(rule, VerificationRule):
             assert isinstance(

--- a/tests/test_tilescope.py
+++ b/tests/test_tilescope.py
@@ -44,6 +44,7 @@ def test_132():
 def test_132_genf():
     searcher = TileScope([Perm((0, 2, 1))], point_placements)
     spec = searcher.auto_search(smallest=True)
+    spec.expand_verified()
     gf = spec.get_genf()
     gf = sympy.series(spec.get_genf(), n=15)
     x = sympy.Symbol("x")

--- a/tilings/strategies/assumption_insertion.py
+++ b/tilings/strategies/assumption_insertion.py
@@ -75,10 +75,6 @@ class AddAssumptionsConstructor(Constructor):
     ):
         raise NotImplementedError
 
-    @staticmethod
-    def get_eq_symbol() -> str:
-        return "↣"
-
 
 class AddAssumptionsStrategy(Strategy[Tiling, GriddedPerm]):
     def __init__(self, assumptions: Iterable[TrackingAssumption], workable=False):
@@ -173,6 +169,10 @@ class AddAssumptionsStrategy(Strategy[Tiling, GriddedPerm]):
     def from_dict(cls, d: dict) -> "AddAssumptionsStrategy":
         assumptions = [TrackingAssumption.from_dict(ass) for ass in d["assumptions"]]
         return cls(assumptions)
+
+    @staticmethod
+    def get_eq_symbol() -> str:
+        return "↣"
 
     def __repr__(self):
         return (

--- a/tilings/strategies/assumption_splitting.py
+++ b/tilings/strategies/assumption_splitting.py
@@ -126,10 +126,6 @@ class Split(Constructor):
     ):
         raise NotImplementedError
 
-    @staticmethod
-    def get_eq_symbol() -> str:
-        return "↣"
-
 
 class SplittingStrategy(Strategy[Tiling, GriddedPerm]):
     """
@@ -336,3 +332,7 @@ class SplittingStrategy(Strategy[Tiling, GriddedPerm]):
     @classmethod
     def from_dict(cls, d: dict) -> "SplittingStrategy":
         return cls(**d)
+
+    @staticmethod
+    def get_eq_symbol() -> str:
+        return "↣"

--- a/tilings/strategies/factor.py
+++ b/tilings/strategies/factor.py
@@ -270,14 +270,6 @@ class Interleaving(CartesianProduct[Tiling, GriddedPerm]):
     ):
         raise NotImplementedError
 
-    @staticmethod
-    def get_eq_symbol() -> str:
-        return "="
-
-    @staticmethod
-    def get_op_symbol() -> str:
-        return "*"
-
 
 class FactorWithInterleavingStrategy(FactorStrategy):
     def formal_step(self) -> str:
@@ -292,9 +284,7 @@ class FactorWithInterleavingStrategy(FactorStrategy):
             interleaving_parameters = self.interleaving_parameters(tiling)
         except ValueError:
             # must be untracked
-            return Interleaving.untracked(
-                tiling, children, self.extra_parameters(tiling, children)
-            )
+            raise NotImplementedError("The interleaving factor was not tracked.")
         return Interleaving(
             tiling,
             children,
@@ -346,6 +336,14 @@ class FactorWithInterleavingStrategy(FactorStrategy):
     ) -> Tuple[GriddedPerm, ...]:
         raise NotImplementedError
 
+    @staticmethod
+    def get_eq_symbol() -> str:
+        return "="
+
+    @staticmethod
+    def get_op_symbol() -> str:
+        return "*"
+
     def __repr__(self) -> str:
         return (
             self.__class__.__name__
@@ -367,12 +365,7 @@ class FactorWithMonotoneInterleavingStrategy(FactorWithInterleavingStrategy):
             interleaving_parameters = self.interleaving_parameters(tiling)
         except ValueError:
             # must be untracked
-            return cast(
-                MonotoneInterleaving,
-                MonotoneInterleaving.untracked(
-                    tiling, children, self.extra_parameters(tiling, children)
-                ),
-            )
+            raise NotImplementedError("The monotone interleaving was not tracked.")
         return MonotoneInterleaving(
             tiling,
             children,

--- a/tilings/strategies/factor.py
+++ b/tilings/strategies/factor.py
@@ -214,27 +214,6 @@ class Interleaving(CartesianProduct[Tiling, GriddedPerm]):
         super().__init__(parent, children, extra_parameters)
         self.interleaving_parameters = tuple(interleaving_parameters)
 
-    @classmethod
-    def untracked(
-        cls,
-        parent: Tiling,
-        children: Iterable[Tiling],
-        extra_parameters: Tuple[Dict[str, str], ...],
-    ) -> "Interleaving":
-        res = cls(parent, children, extra_parameters, [])
-
-        def f(*args, **kwargs):
-            raise NotImplementedError(
-                "enumeration for untracked interleaving factors is not implemented"
-            )
-
-        # Overwriting methods is bad practice, but useful here!
-        res.get_recurrence = f  # type: ignore
-        res.get_equation = f  # type: ignore
-        res.get_sub_objects = f  # type: ignore
-        res.random_sample_sub_objects = f  # type: ignore
-        return res
-
     @staticmethod
     def is_equivalence() -> bool:
         return False

--- a/tilings/strategies/fusion.py
+++ b/tilings/strategies/fusion.py
@@ -478,10 +478,6 @@ class FusionConstructor(Constructor[Tiling, GriddedPerm]):
     ):
         raise NotImplementedError
 
-    @staticmethod
-    def get_eq_symbol() -> str:
-        return "↣"
-
 
 class FusionStrategy(Strategy[Tiling, GriddedPerm]):
     def __init__(
@@ -515,7 +511,7 @@ class FusionStrategy(Strategy[Tiling, GriddedPerm]):
     ) -> FusionConstructor:
         if not self.tracked:
             # constructor only enumerates when tracked.
-            return FusionConstructor("n", {}, tuple(), tuple(), tuple(), 0, 0)
+            raise NotImplementedError("The fusion strategy was not tracked.")
         # Need to recompute some info to count, so ignoring passed in children
         algo = self.fusion_algorithm(comb_class)
         if not algo.fusable():
@@ -629,6 +625,10 @@ class FusionStrategy(Strategy[Tiling, GriddedPerm]):
     @classmethod
     def from_dict(cls, d: dict) -> "FusionStrategy":
         return cls(**d)
+
+    @staticmethod
+    def get_eq_symbol() -> str:
+        return "↣"
 
     def __repr__(self) -> str:
         return (


### PR DESCRIPTION
### Changed
- the `get_eq_symbol` and `get_op_symbol` are moved to `Strategy` rather than
  `Constructor`

 ### Fixed
- untracked constructors raise `NotImplementedError`