### PR TITLE
Fuse non empty regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - insertion packs now use the `one_cell_only` option, and no longer use
   `RequirementCorroborationFactory`
 
+### Fixed
+- only fuse non-empty regions to avoid creating unintentional rules a -> b
+  where a and b are equivalent
+
 ## [2.2.0] - 2020-07-08
 ### Added
 - add the `can_be_equivalent` methods to `AddAssumptionsStrategy`,

--- a/tests/algorithms/test_fusion.py
+++ b/tests/algorithms/test_fusion.py
@@ -3,6 +3,7 @@ import pytest
 from permuta import Perm
 from tilings import GriddedPerm, Tiling
 from tilings.algorithms import ComponentFusion, Fusion
+from tilings.assumptions import TrackingAssumption
 
 
 class TestFusion:
@@ -563,3 +564,30 @@ class TestComponentFusion(TestFusion):
     def test_is_valid_count(self, row_fusion):
         with pytest.raises(NotImplementedError):
             row_fusion._is_valid_count(2, GriddedPerm(Perm((0,)), ((0, 0),)))
+
+    def test_fusing_empty_region(self):
+        tiling = Tiling(
+            obstructions=(
+                GriddedPerm(Perm((0, 1)), ((0, 0), (0, 0))),
+                GriddedPerm(Perm((0, 1)), ((0, 0), (0, 1))),
+                GriddedPerm(Perm((0, 1)), ((0, 1), (0, 1))),
+                GriddedPerm(Perm((1, 0)), ((0, 3), (0, 0))),
+                GriddedPerm(Perm((1, 0)), ((0, 3), (0, 1))),
+                GriddedPerm(Perm((0, 1, 2)), ((0, 0), (0, 2), (0, 2))),
+                GriddedPerm(Perm((0, 1, 2)), ((0, 0), (0, 2), (0, 3))),
+                GriddedPerm(Perm((0, 1, 2)), ((0, 0), (0, 3), (0, 3))),
+                GriddedPerm(Perm((0, 1, 2)), ((0, 1), (0, 2), (0, 2))),
+                GriddedPerm(Perm((0, 1, 2)), ((0, 1), (0, 2), (0, 3))),
+                GriddedPerm(Perm((0, 1, 2)), ((0, 1), (0, 3), (0, 3))),
+                GriddedPerm(Perm((0, 1, 2)), ((0, 2), (0, 2), (0, 2))),
+                GriddedPerm(Perm((0, 1, 2)), ((0, 2), (0, 3), (0, 3))),
+                GriddedPerm(Perm((2, 0, 1)), ((0, 3), (0, 2), (0, 2))),
+                GriddedPerm(Perm((0, 1, 2, 3)), ((0, 3), (0, 3), (0, 3), (0, 3))),
+                GriddedPerm(Perm((0, 2, 3, 1)), ((0, 2), (0, 2), (0, 3), (0, 2))),
+                GriddedPerm(Perm((0, 2, 3, 1)), ((0, 3), (0, 3), (0, 3), (0, 3))),
+                GriddedPerm(Perm((3, 0, 1, 2)), ((0, 3), (0, 3), (0, 3), (0, 3))),
+            ),
+            requirements=((GriddedPerm(Perm((0, 1)), ((0, 3), (0, 3))),),),
+            assumptions=(TrackingAssumption((GriddedPerm(Perm((0,)), ((0, 0),)),)),),
+        )
+        assert not Fusion(tiling, col_idx=0, tracked=True).fusable()


### PR DESCRIPTION
### Fixed
- only fuse non-empty regions to avoid creating unintentional rules a -> b
  where a and b are equivalent