### PR TITLE
Add assumptions bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `ComponentAssumption`
 - a tiling factors if a `ComponentAssumption` if the components of the region
   split into the factors
-- mark the child of an interleaving factor rule as inferable
 
 ### Fixed
 - only fuse non-empty regions to avoid creating unintentional rules a -> b

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - only fuse non-empty regions to avoid creating unintentional rules a -> b
   where a and b are equivalent
 - remove duplicate assumptions in the `AddAssumptionsStrategy`
-- `Tiling.from_dict` will make a `Tiling` with no assumptions if ther
+- `Tiling.from_dict` will make a `Tiling` with no assumptions if the
   `assumptions` key is not in the dictionary.
 - a factor with interleaving strategy has `inferrable=True`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - only fuse non-empty regions to avoid creating unintentional rules a -> b
   where a and b are equivalent
+- remove duplicate assumptions in the `AddAssumptionsStrategy`
+- `Tiling.from_dict` will make a `Tiling` with no assumptions if ther
+  `assumptions` key is not in the dictionary.
+- a factor with interleaving strategy has `inferrable=True`
 
 ## [2.2.0] - 2020-07-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `ComponentAssumption`
 - a tiling factors if a `ComponentAssumption` if the components of the region
   split into the factors
+- mark the child of an interleaving factor rule as inferable
 
 ### Fixed
 - only fuse non-empty regions to avoid creating unintentional rules a -> b

--- a/tests/strategies/test_factors.py
+++ b/tests/strategies/test_factors.py
@@ -189,7 +189,9 @@ def test_rule(
     factor_rules, factor_with_int_rules, factor_with_mon_int_rules, not_fact_tiling
 ):
     all_rules = factor_rules + factor_with_int_rules + factor_with_mon_int_rules
-    assert all(not rule.inferrable for rule in all_rules)
+    assert all(not rule.inferrable for rule in factor_rules)
+    assert all(rule.inferrable for rule in factor_with_mon_int_rules)
+    assert all(rule.inferrable for rule in factor_with_int_rules)
     assert all(len(rule.strategy.partition) == len(rule.children) for rule in all_rules)
     assert all(rule.workable for rule in all_rules)
     assert all(not rule.possibly_empty for rule in all_rules)

--- a/tests/test_tiling.py
+++ b/tests/test_tiling.py
@@ -488,6 +488,11 @@ def test_bytes(compresstil):
 
 def test_json(compresstil):
     assert compresstil == Tiling.from_json(json.dumps(compresstil.to_jsonable()))
+    # For backward compatibility make sure we can load from json that don't have
+    # the assumptions field
+    d = compresstil.to_jsonable()
+    d.pop("assumptions")
+    assert compresstil == Tiling.from_json(json.dumps(d))
 
 
 def test_cell_within_bounds(

--- a/tilings/strategies/assumption_insertion.py
+++ b/tilings/strategies/assumption_insertion.py
@@ -82,7 +82,7 @@ class AddAssumptionsConstructor(Constructor):
 
 class AddAssumptionsStrategy(Strategy[Tiling, GriddedPerm]):
     def __init__(self, assumptions: Iterable[TrackingAssumption], workable=False):
-        self.assumptions = tuple(assumptions)
+        self.assumptions = tuple(set(assumptions))
         super().__init__(
             ignore_parent=False,
             inferrable=True,
@@ -215,13 +215,13 @@ class AddInterleavingAssumptionFactory(StrategyFactory[Tiling]):
         Yield an AddAssumption strategy for the given component if needed.
         """
         cols, rows = interleaving_rows_and_cols(components)
-        assumptions = [
+        assumptions = set(
             ass
             for ass in chain.from_iterable(
                 assumptions_to_add(cells, cols, rows) for cells in components
             )
             if ass not in comb_class.assumptions
-        ]
+        )
         if assumptions:
             strategy = AddAssumptionsStrategy(assumptions, workable=True)
             yield strategy(comb_class)

--- a/tilings/strategies/factor.py
+++ b/tilings/strategies/factor.py
@@ -42,7 +42,11 @@ class FactorStrategy(CartesianProductStrategy[Tiling, GriddedPerm]):
         workable: bool = True,
     ):
         self.partition = tuple(sorted(tuple(sorted(p)) for p in partition))
-        super().__init__(ignore_parent=ignore_parent, workable=workable)
+        super().__init__(
+            ignore_parent=ignore_parent,
+            workable=workable,
+            inferrable=any(interleaving_rows_and_cols(partition)),
+        )
 
     def decomposition_function(self, tiling: Tiling) -> Tuple[Tiling, ...]:
         return tuple(tiling.sub_tiling(cells) for cells in self.partition)
@@ -60,9 +64,7 @@ class FactorStrategy(CartesianProductStrategy[Tiling, GriddedPerm]):
         ):
             for idx, child in enumerate(children):
                 # TODO: consider skew/sum
-                new_assumption = child.forward_map_assumption(
-                    assumption, check_avoidance=False
-                )
+                new_assumption = child.forward_map_assumption(assumption)
                 if new_assumption.gps:
                     child_var = child.get_parameter(new_assumption)
                     extra_parameters[idx][parent_var] = child_var

--- a/tilings/strategies/factor.py
+++ b/tilings/strategies/factor.py
@@ -42,10 +42,9 @@ class FactorStrategy(CartesianProductStrategy[Tiling, GriddedPerm]):
         workable: bool = True,
     ):
         self.partition = tuple(sorted(tuple(sorted(p)) for p in partition))
+        inferrable = any(interleaving_rows_and_cols(self.partition))
         super().__init__(
-            ignore_parent=ignore_parent,
-            workable=workable,
-            inferrable=any(interleaving_rows_and_cols(partition)),
+            ignore_parent=ignore_parent, workable=workable, inferrable=inferrable
         )
 
     def decomposition_function(self, tiling: Tiling) -> Tuple[Tiling, ...]:

--- a/tilings/tiling.py
+++ b/tilings/tiling.py
@@ -493,12 +493,7 @@ class Tiling(CombinatorialClass):
         serialized Tiling object."""
         obstructions = map(GriddedPerm.from_dict, d["obstructions"])
         requirements = map(lambda x: map(GriddedPerm.from_dict, x), d["requirements"])
-        assumptions = (
-            map(TrackingAssumption.from_dict, d["assumptions"])
-            if "assumptions" in d
-            else []
-        )
-
+        assumptions = map(TrackingAssumption.from_dict, d.get("assumptions", []))
         return cls(
             obstructions=obstructions,
             requirements=requirements,

--- a/tilings/tiling.py
+++ b/tilings/tiling.py
@@ -493,7 +493,12 @@ class Tiling(CombinatorialClass):
         serialized Tiling object."""
         obstructions = map(GriddedPerm.from_dict, d["obstructions"])
         requirements = map(lambda x: map(GriddedPerm.from_dict, x), d["requirements"])
-        assumptions = map(TrackingAssumption.from_dict, d["assumptions"])
+        assumptions = (
+            map(TrackingAssumption.from_dict, d["assumptions"])
+            if "assumptions" in d
+            else []
+        )
+
         return cls(
             obstructions=obstructions,
             requirements=requirements,


### PR DESCRIPTION
### Fixed
- remove duplicate assumptions in the `AddAssumptionsStrategy`
- `Tiling.from_dict` will make a `Tiling` with no assumptions if the
  `assumptions` key is not in the dictionary.
- a factor with interleaving strategy has `inferrable=True`