### PR TITLE
remove error string test

### DIFF
--- a/tests/strategies/test_row_column_separation.py
+++ b/tests/strategies/test_row_column_separation.py
@@ -132,7 +132,6 @@ def test_row_col_seperation(
     for t in not_separable_tilings:
         with pytest.raises(StrategyDoesNotApply) as excinfo:
             RowColumnSeparationStrategy()(t).children
-        assert "row and column separation does not apply" in str(excinfo)
     t1_sep = Tiling(
         obstructions=(
             GriddedPerm(Perm((0,)), ((0, 0),)),
@@ -212,7 +211,6 @@ def test_rule(seperable_tiling1, not_separable_tilings):
     )
     with pytest.raises(StrategyDoesNotApply) as excinfo:
         RowColumnSeparationStrategy()(not_separable_tilings[0]).children
-    assert "row and column separation does not apply" in str(excinfo)
 
 
 def test_formal_step(seperable_tiling1):

--- a/tests/strategies/test_row_column_separation.py
+++ b/tests/strategies/test_row_column_separation.py
@@ -130,7 +130,7 @@ def test_row_col_seperation(
     )
 
     for t in not_separable_tilings:
-        with pytest.raises(StrategyDoesNotApply) as excinfo:
+        with pytest.raises(StrategyDoesNotApply):
             RowColumnSeparationStrategy()(t).children
     t1_sep = Tiling(
         obstructions=(
@@ -209,7 +209,7 @@ def test_rule(seperable_tiling1, not_separable_tilings):
         RowColumnSeparationStrategy().decomposition_function(not_separable_tilings[0])
         is None
     )
-    with pytest.raises(StrategyDoesNotApply) as excinfo:
+    with pytest.raises(StrategyDoesNotApply):
         RowColumnSeparationStrategy()(not_separable_tilings[0]).children
 
 


### PR DESCRIPTION
This test will fail due to a small change in the error string that is returned. The type of error staying the same is all we should check in my opinion.