### PR TITLE
fix isolation level issue on component fusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - removed the length argument to the `insertion_point_placements` pack which
   was not implemented, and thus raising an error.
 - Bug that occurred when factoring the empty tiling
+- isolation levels were not being passed to component fusion
 
 
 ## [2.2.0] - 2020-07-08

--- a/tilings/strategies/fusion.py
+++ b/tilings/strategies/fusion.py
@@ -724,17 +724,27 @@ class ComponentFusionFactory(StrategyFactory[Tiling]):
             return
         cols, rows = comb_class.dimensions
         for row_idx in range(rows - 1):
-            algo = ComponentFusion(comb_class, row_idx=row_idx, tracked=self.tracked,)
+            algo = ComponentFusion(
+                comb_class,
+                row_idx=row_idx,
+                tracked=self.tracked,
+                isolation_level=self.isolation_level,
+            )
             if algo.fusable():
                 fused_tiling = algo.fused_tiling()
-                yield ComponentFusionStrategy(row_idx=row_idx, tracked=self.tracked,)(
+                yield ComponentFusionStrategy(row_idx=row_idx, tracked=self.tracked)(
                     comb_class, (fused_tiling,)
                 )
         for col_idx in range(cols - 1):
-            algo = ComponentFusion(comb_class, col_idx=col_idx, tracked=self.tracked,)
+            algo = ComponentFusion(
+                comb_class,
+                col_idx=col_idx,
+                tracked=self.tracked,
+                isolation_level=self.isolation_level,
+            )
             if algo.fusable():
                 fused_tiling = algo.fused_tiling()
-                yield ComponentFusionStrategy(col_idx=col_idx, tracked=self.tracked,)(
+                yield ComponentFusionStrategy(col_idx=col_idx, tracked=self.tracked)(
                     comb_class, (fused_tiling,)
                 )
 


### PR DESCRIPTION
The `isolation_level` parameter was not being passed into the component fusion algo class.