### PR TITLE
Invalid min point for fusion algo

### DIFF
--- a/tests/algorithms/test_fusion.py
+++ b/tests/algorithms/test_fusion.py
@@ -306,6 +306,18 @@ class TestFusion:
             ],
         )
 
+    def test_positive_fusion(self):
+        t = Tiling(
+            obstructions=[
+                GriddedPerm((0, 1), [(0, 0), (0, 0)]),
+                GriddedPerm((0, 1), [(0, 0), (1, 0)]),
+                GriddedPerm((0, 1), [(1, 0), (1, 0)]),
+            ],
+            requirements=[[GriddedPerm((0,), [(0, 0)])]],
+        )
+        algo = Fusion(t, col_idx=0)
+        assert algo.min_left_right_points() == (1, 0)
+
 
 class TestComponentFusion(TestFusion):
     @pytest.fixture

--- a/tilings/algorithms/fusion.py
+++ b/tilings/algorithms/fusion.py
@@ -209,6 +209,9 @@ class Fusion:
         return False
 
     def min_left_right_points(self) -> Tuple[int, int]:
+        # Make sure that the req fuse counter has been computed so that
+        # positive left and right or fine
+        self.requirements_fuse_counters
         return int(self._positive_left), int(self._positive_right)
 
     @property

--- a/tilings/algorithms/fusion.py
+++ b/tilings/algorithms/fusion.py
@@ -211,6 +211,7 @@ class Fusion:
     def min_left_right_points(self) -> Tuple[int, int]:
         # Make sure that the req fuse counter has been computed so that
         # positive left and right or fine
+        # pylint: disable=pointless-statement
         self.requirements_fuse_counters
         return int(self._positive_left), int(self._positive_right)
 


### PR DESCRIPTION
If you call the min number of point on the fusion algorithm before checking if
it is fusable you get an incorrect answer. Just added the failing test for now
but will fix after merging reverse fusion
