### PR TITLE
removed redundant is empty check in fusion algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Moved several local function in `RearrangeConstructor` outward to make it pickleable
 - Fixed isolated fusion bug
 
+### Fixed 
+- Removed a redundant `Tiling.is_empty` check in the fusion algorithm. 
+
 ### Deprecated
 - Python 3.6 is no longer supported
 
@@ -211,7 +214,6 @@ list.
 ### Fixed
 - Infinite recursion issue in get_genf.
 - Close mongo when finished.
-- Removed a redundant `Tiling.is_empty` check in the fusion algorithm. 
 
 ## [0.0.1] - 2019-06-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,7 @@ list.
 ### Fixed
 - Infinite recursion issue in get_genf.
 - Close mongo when finished.
+- Removed a redundant `Tiling.is_empty` check in the fusion algorithm. 
 
 ## [0.0.1] - 2019-06-02
 ### Added

--- a/tilings/algorithms/fusion.py
+++ b/tilings/algorithms/fusion.py
@@ -374,9 +374,6 @@ class Fusion:
             and req_fusable
             and ass_fusable
             and self._check_isolation_level()
-            and not self.fused_tiling()
-            .add_list_requirement(list(self.new_assumption().gps))
-            .is_empty()
         )
 
     def fused_tiling(self) -> "Tiling":


### PR DESCRIPTION
@enadeau: We will now add rules from fusion which are empty cell inferral after this is added? Will the fusion rule make them 'equivalent'? Will CSS favour the empty cell inferral which may happen later?

@jaypantone this was originally added due to a bug you found when running
```
This must be all_the_strategies(2)?
Found specification for 0123_0231_3012 with all_the_strategies_fusion_isolated_single_fusion  of size 42 in 6:20:32.
        Enumeration: Counting or sending message or writing failed: maximum recursion depth exceeded
```
could you do run again to see if the issue persists after removing this check?