### PR TITLE
Old strategy JSON

### DIFF
--- a/tests/strategies/old_rule_json.jsonl
+++ b/tests/strategies/old_rule_json.jsonl
@@ -1,0 +1,1 @@
+{"class_module": "tilings.strategies.verification", "strategy_class": "LocallyFactorableVerificationStrategy", "ignore_parent": true}

--- a/tests/strategies/test_json_encoding.py
+++ b/tests/strategies/test_json_encoding.py
@@ -1,4 +1,5 @@
 import json
+import os
 from itertools import product
 
 import pytest
@@ -386,9 +387,18 @@ strategy_objects = (
     ]
 )
 
+__location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+with open(os.path.join(__location__, "old_rule_json.jsonl")) as fp:
+    strategy_dicts = list(map(json.loads, fp.readlines()))
+
 
 @pytest.mark.parametrize("strategy", strategy_objects)
 def test_json_encoding(strategy):
     strategy_new = json_encode_decode(strategy)
     print(strategy)
     assert_same_strategy(strategy, strategy_new)
+
+
+@pytest.mark.parametrize("strat_dict", strategy_dicts)
+def test_old_json_compatibility(strat_dict):
+    Strategy.from_dict(strat_dict)

--- a/tilings/strategies/verification.py
+++ b/tilings/strategies/verification.py
@@ -126,10 +126,10 @@ class BasisAwareVerificationStrategy(TileScopeVerificationStrategy):
     def from_dict(
         cls: Type[BasisAwareVerificationStrategyType], d: dict
     ) -> BasisAwareVerificationStrategyType:
-        if d["basis"] is not None:
+        if "basis" in d and d["basis"] is not None:
             basis: Optional[List[Perm]] = [Perm(p) for p in d.pop("basis")]
         else:
-            basis = d.pop("basis")
+            basis = d.pop("basis", None)
         return cls(basis=basis, **d)
 
 


### PR DESCRIPTION
This introduces a new series of test where we make sure we don't brake backward
compatibility with JSON.

When we run into a backward compatibility problem we can add the JSON to the new
file to get it tested.
