### PR TITLE
shifts locally factorable

### DIFF
--- a/tests/strategies/test_verification.py
+++ b/tests/strategies/test_verification.py
@@ -273,7 +273,7 @@ class TestLocallyFactorableVerificationStrategy(CommonTest):
             basis=[Perm((0, 1, 3, 2))], symmetry=True
         )
         assert strat_with_sym(t1).children == (Tiling.from_string("0132"),)
-        assert strat_with_sym(t1.rotate90()).children == (Tiling.from_string("4312"),)
+        assert strat_with_sym(t1.rotate90()).children == (Tiling.from_string("0132"),)
 
     def test_shifts(self):
         t1 = Tiling(

--- a/tilings/algorithms/locally_factorable_shift.py
+++ b/tilings/algorithms/locally_factorable_shift.py
@@ -11,7 +11,7 @@ from comb_spec_searcher.strategies.constructor import CartesianProduct, Disjoint
 from comb_spec_searcher.strategies.rule import Rule, VerificationRule
 from comb_spec_searcher.strategies.strategy import VerificationStrategy
 from comb_spec_searcher.typing import CSSstrategy
-from permuta import Perm
+from permuta import Av, Perm
 from tilings import GriddedPerm, Tiling
 
 __all__ = ["shift_from_spec"]
@@ -35,7 +35,10 @@ class NoBasisVerification(VerificationStrategy[Tiling, GriddedPerm]):
         super().__init__()
 
     def formal_step(self) -> str:
-        return "No cell is the basis"
+        cls = Av(min(self.symmetries))
+        if len(self.symmetries) == 1:
+            return f"No cell is {cls}"
+        return f"No cell is a symmetry of {cls}"
 
     def verified(self, comb_class: Tiling) -> bool:
         cell_bases = (frozenset(obs) for obs, _ in comb_class.cell_basis().values())

--- a/tilings/algorithms/locally_factorable_shift.py
+++ b/tilings/algorithms/locally_factorable_shift.py
@@ -1,6 +1,5 @@
-import itertools
 import logging
-from typing import Dict, Optional, Set, Tuple
+from typing import Dict, Optional, Tuple
 
 from logzero import logger
 
@@ -10,8 +9,12 @@ from comb_spec_searcher import (
 )
 from comb_spec_searcher.strategies.constructor import CartesianProduct, DisjointUnion
 from comb_spec_searcher.strategies.rule import Rule, VerificationRule
-from permuta import Basis, Perm
+from comb_spec_searcher.strategies.strategy import VerificationStrategy
+from comb_spec_searcher.typing import CSSstrategy
+from permuta import Av, Basis, Perm
 from tilings import GriddedPerm, Tiling
+
+__all__ = ["shift_from_spec"]
 
 
 class TmpLoggingLevel:
@@ -26,89 +29,75 @@ class TmpLoggingLevel:
         logger.setLevel(self.curent_level)
 
 
-class LocallyFactorableShift:
-    def __init__(
-        self, rule: VerificationRule[Tiling, GriddedPerm], basis: Tuple[Perm, ...]
-    ) -> None:
-        self.rule = rule
+class NoBasisVerification(VerificationStrategy[Tiling, GriddedPerm]):
+    def __init__(self, basis: Tuple[Perm, ...]) -> None:
         self.basis = Basis(*basis)
-        self._spec: Optional[CombinatorialSpecification] = None
-        self.traverse_cache: Dict[Tiling, Optional[int]] = {}
+        super().__init__()
 
-    @property
-    def spec(self) -> CombinatorialSpecification:
-        if self._spec is None:
-            pack = self.rule.pack()
-            with TmpLoggingLevel(logging.WARN):
-                css = CombinatorialSpecificationSearcher(self.rule.comb_class, pack)
-                spec = css.auto_search()
-            self._spec = spec
-        return self._spec
+    def formal_step(self) -> str:
+        return f"No cell is {Av(self.basis)}"
 
-    @staticmethod
-    def cell_basis(t: Tiling) -> Set[Basis]:
-        """
-        Return the one by one classes in the cells.
-        """
-        all_bases: Set[Basis] = set()
-        for obs, _ in t.cell_basis().values():
-            b = Basis.from_iterable(obs)
-            all_bases.add(b)
-        return all_bases
+    def verified(self, comb_class: Tiling) -> bool:
+        cell_bases = (Basis(*obs) for obs, _ in comb_class.cell_basis().values())
+        return self.basis not in cell_bases
 
-    def _reliance(self, t: Tiling) -> Optional[int]:
-        """
-        Return the reliance of the tiling on the basis according to the spec.
-        """
-        rule = self.spec.rules_dict[t]
-        if t in self.traverse_cache:
-            return self.traverse_cache[t]
-        if self.basis not in self.cell_basis(t):
+    @classmethod
+    def from_dict(cls, d: dict) -> CSSstrategy:
+        raise NotImplementedError
+
+    def to_jsonable(self) -> dict:
+        raise NotImplementedError
+
+
+def expanded_spec(
+    tiling: Tiling, strat: VerificationStrategy, basis: Tuple[Perm, ...]
+) -> CombinatorialSpecification:
+    """
+    Return a spec where any tiling that does not have the basis in one cell is
+    verified.
+    """
+    pack = strat.pack(tiling).add_verification(
+        NoBasisVerification(basis), apply_first=True
+    )
+    with TmpLoggingLevel(logging.WARN):
+        css = CombinatorialSpecificationSearcher(tiling, pack)
+        spec = css.auto_search()
+    return spec
+
+
+def shift_from_spec(
+    tiling: Tiling, strat: VerificationStrategy, basis: Tuple[Perm, ...]
+) -> Optional[int]:
+    assert basis
+    traverse_cache: Dict[Tiling, Optional[int]] = {}
+    spec = expanded_spec(tiling, strat, basis)
+
+    def traverse(t: Tiling) -> Optional[int]:
+        rule = spec.rules_dict[t]
+        if t in traverse_cache:
+            return traverse_cache[t]
+        res: Optional[int]
+        if isinstance(rule.strategy, NoBasisVerification):
             res = None
         elif t.dimensions == (1, 1):
             res = 0
         elif isinstance(rule, VerificationRule):
-            res = LocallyFactorableShift(rule, self.basis).shift()
+            res = shift_from_spec(tiling, rule.strategy, basis)
         elif isinstance(rule, Rule) and isinstance(rule.constructor, DisjointUnion):
-            children_reliance = [self._reliance(c) for c in rule.children]
+            children_reliance = [traverse(c) for c in rule.children]
             res = min([r for r in children_reliance if r is not None], default=None)
         elif isinstance(rule, Rule) and isinstance(rule.constructor, CartesianProduct):
             min_points = [len(next(c.minimal_gridded_perms())) for c in rule.children]
             point_sum = sum(min_points)
             shifts = [point_sum - mpoint for mpoint in min_points]
-            children_reliance = [self._reliance(c) for c in rule.children]
+            children_reliance = [traverse(c) for c in rule.children]
             res = min(
                 [r + s for r, s in zip(children_reliance, shifts) if r is not None],
                 default=None,
             )
         else:
             raise NotImplementedError(rule)
-        self.traverse_cache[t] = res
+        traverse_cache[t] = res
         return res
 
-    def shift_from_spec(self) -> int:
-        res = self._reliance(self.rule.comb_class)
-        if res is None:
-            raise RuntimeError(f"No reliance on child:\n{self.rule}")
-        return res
-
-    def shift_from_theory(self) -> int:
-        """
-        The shift from the conjectured formula.
-        """
-        min_gps = self.rule.comb_class.minimal_gridded_perms()
-        cells_with_basis = [
-            cell
-            for cell, (obs, _) in self.rule.comb_class.cell_basis().items()
-            if Basis.from_iterable(obs) == self.basis
-        ]
-        return min(
-            sum(1 for c in gp.pos if c != cell)
-            for cell, gp in itertools.product(cells_with_basis, min_gps)
-        )
-
-    def shift(self) -> int:
-        from_spec = self.shift_from_spec()
-        from_conjecture = self.shift_from_theory()
-        assert from_spec == from_conjecture
-        return from_conjecture
+    return traverse(tiling)

--- a/tilings/algorithms/locally_factorable_shift.py
+++ b/tilings/algorithms/locally_factorable_shift.py
@@ -59,10 +59,6 @@ def expanded_spec(
     Return a spec where any tiling that does not have the basis in one cell is
     verified.
     """
-    print(symmetries)
-    print(tiling)
-    print(repr(strat))
-    print(strat.__dict__)
     pack = strat.pack(tiling).add_verification(
         NoBasisVerification(symmetries), apply_first=True
     )

--- a/tilings/strategies/verification.py
+++ b/tilings/strategies/verification.py
@@ -72,9 +72,11 @@ class BasisAwareVerificationStrategy(TileScopeVerificationStrategy):
             isinstance(p, Perm) for p in self._basis
         ), "Element of the basis must be Perm"
         if symmetry:
-            self.symmetries = set(frozenset(b) for b in all_symmetry_sets(self._basis))
+            self.symmetries = frozenset(
+                frozenset(b) for b in all_symmetry_sets(self._basis)
+            )
         else:
-            self.symmetries = set([frozenset(self._basis)])
+            self.symmetries = frozenset([frozenset(self._basis)])
         super().__init__(ignore_parent=ignore_parent)
 
     def change_basis(
@@ -417,7 +419,9 @@ class LocallyFactorableVerificationStrategy(BasisAwareVerificationStrategy):
         if self.verified(comb_class):
             if not self.basis:
                 return ()
-            sfs = locally_factorable_shift.shift_from_spec(comb_class, self, self.basis)
+            sfs = locally_factorable_shift.shift_from_spec(
+                comb_class, self, self.symmetries
+            )
             if sfs is not None:
                 return (Tiling.from_perms(self.basis),)
             return ()
@@ -432,7 +436,9 @@ class LocallyFactorableVerificationStrategy(BasisAwareVerificationStrategy):
                 raise StrategyDoesNotApply
         if not children:
             return ()
-        shift = locally_factorable_shift.shift_from_spec(comb_class, self, self.basis)
+        shift = locally_factorable_shift.shift_from_spec(
+            comb_class, self, self.symmetries
+        )
         assert shift is not None
         return (shift,)
 


### PR DESCRIPTION
I've changed the locally factorable shift computation to rely on the expansion instead of the subobstruction inferral. To speed up the computation of the shift I've created a verification strategy that verifies any tiling that doesn't have a cell that is the root. This will reduce the amount of expansion needed to compute the shifts and the children.