### PR TITLE
remove the remove_strategy defined on css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ swapped around a fusable row or column.
 - `PositiveCorroborationFactory` that inserts into cells which if positive makes 
   another cell empty. Also, the `PointCorroborationFactory`, which does this for 
   point or empty cells which is added to most packs.
-- `TileScopePack.remove_strategy` method that removes a strategy from a pack.
 - `TargetedCellInsertionFactory` which inserts factors of gridded perms if it can 
   lead to factoring out a verified sub tiling. 
 - `ComponentVerificationStrategy` which is added to component fusion packs. 

--- a/tilings/strategy_pack.py
+++ b/tilings/strategy_pack.py
@@ -280,28 +280,6 @@ class TileScopePack(StrategyPack):
             raise ValueError("Symmetries already turned on.")
         return super().add_symmetry(strat.SymmetriesFactory(), "symmetries")
 
-    def remove_strategy(self, strategy: CSSstrategy):
-        """remove the strategy from the pack"""
-        d = strategy.to_jsonable()
-
-        def replace_list(strats):
-            """Return a new list with the replaced fusion strat."""
-            res = []
-            for strategy in strats:
-                if not strategy.to_jsonable() == d:
-                    res.append(strategy)
-            return res
-
-        return self.__class__(
-            ver_strats=replace_list(self.ver_strats),
-            inferral_strats=replace_list(self.inferral_strats),
-            initial_strats=replace_list(self.initial_strats),
-            expansion_strats=list(map(replace_list, self.expansion_strats)),
-            name=self.name,
-            symmetries=replace_list(self.symmetries),
-            iterative=self.iterative,
-        )
-
     def kitchen_sinkify(  # pylint: disable=R0912
         self, short_obs_len: int, obs_inferral_len: int, tracked: bool
     ) -> "TileScopePack":


### PR DESCRIPTION
this method is now defined on `comb_spec_searcher.StrategyPack`
https://github.com/PermutaTriangle/comb_spec_searcher/pull/326