### PR TITLE
All at once obstruction inferral

### DIFF
--- a/tests/algorithms/test_obstruction_inferral.py
+++ b/tests/algorithms/test_obstruction_inferral.py
@@ -173,6 +173,7 @@ class TestSubobstructionInferral(CommonTest):
         assert obs_not_inf.new_obs() == []
         assert obs_inf2.new_obs() == [
             GriddedPerm((0, 1), ((0, 0), (2, 0))),
+            GriddedPerm((0, 2, 1), ((0, 0), (0, 0), (2, 0))),
         ]
 
     def test_obstruction_inferral(self, obs_inf2):


### PR DESCRIPTION
We generate to a theoretical max length to test for containment, instead of an is empty check for each obstruction. 