### PR TITLE
adds flag to allow factorable requirement insertions, default = False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [3.1.0] - 2022-01-17
 ### Added
-- `Tiling.remove_requirement` method that removes a requirement from a tiling.
-- `RemoveRequirementFactory` which adds the rules where we insert a requirement to a
-tiling after we first remove that requirement. This is added to
-`LocallyFactorableVerificationStrategy.pack`.
-- The tiling initialiser will now add factors of obstructions if it is implied by
-multiple different obs and one requirement list of size possibly greater than one.
-Previously it was only doing the case where a single ob's factor is implied by a
-requirement.
 - added `TileScopePack.requirement_and_row_and_col_placements`
 - `AssumptionAndPointJumpingFactory` which adds rules where requirements and/or
   assumptions are swapped around a fusable row or column.
@@ -49,21 +39,13 @@ swapped around a fusable row or column.
 - `UnfusionFactory` that unfuses either all the rows or columns. Also non-productive.
 - `FusableRowAndColumnPlacementFactory` places fusable rows and columns.
 
-
 ### Fixed
-- `ForgetTrackedSearcher` was not retroactively applying strategies that had a `basis`.
-- Bug with sliding symmetries
-- The tiling initialiser was not removing duplicate/redundant requirements.
 - `Factor` was not factoring correctly with respect to component assumptions.
 - `ComponentAssumption` are flipped when taking symmetries
 - `Tiling.get_minimum_value` fixed for component assumptions
 - `RearrangeAssumptionFactory` will ignore component assumptions
 
 ### Changed
-- One by one verification will now only verify subclasses of the given basis.
-- Verification strategies no longer ignore parent
-- `TrackedSearcher` now uses a `TrackedQueue` and is able to work with all packs
-   and new future strategies.
 - `TileScopePack.make_tracked` will add the appropriate tracking methods for
   interleaving factors and make strategies tracked if it can be.
 - The `GriddedPermReduction` limits the size of obstructions it tries to infer in
@@ -80,10 +62,35 @@ swapped around a fusable row or column.
 - `is_component` method of assumptions updated to consider cell decomposition
 - `AddAssumptionsStrategy.is_reverible` is now True when the assumption covers the 
   whole tiling.
+- The default behavior for `RequirementInsertion` is to allow insertion of factorable
+  requirements
 
 ### Removed
 - `AddInterleavingAssumptionsFactory`. The factor strategy now adds the relevant 
   assumptions where necessary directly, lowering the number of CVs needed. 
+
+
+## [3.1.0] - 2022-01-17
+### Added
+- `Tiling.remove_requirement` method that removes a requirement from a tiling.
+- `RemoveRequirementFactory` which adds the rules where we insert a requirement to a
+tiling after we first remove that requirement. This is added to
+`LocallyFactorableVerificationStrategy.pack`.
+- The tiling initialiser will now add factors of obstructions if it is implied by
+multiple different obs and one requirement list of size possibly greater than one.
+Previously it was only doing the case where a single ob's factor is implied by a
+requirement.
+
+### Fixed
+- `ForgetTrackedSearcher` was not retroactively applying strategies that had a `basis`.
+- Bug with sliding symmetries
+- The tiling initialiser was not removing duplicate/redundant requirements.
+
+### Changed
+- One by one verification will now only verify subclasses of the given basis.
+- Verification strategies no longer ignore parent
+- `TrackedSearcher` now uses a `TrackedQueue` and is able to work with all packs
+   and new future strategies.
 
 ### Deprecated
 - Python 3.7 is no longer supported

--- a/tilings/strategies/requirement_insertion.py
+++ b/tilings/strategies/requirement_insertion.py
@@ -400,7 +400,7 @@ class RequirementInsertionFactory(RequirementInsertionWithRestrictionFactory):
         extra_basis: Optional[List[Perm]] = None,
         limited_insertion: bool = True,
         ignore_parent: bool = False,
-        allow_factorable_insertions: bool = False,
+        allow_factorable_insertions: bool = True,
     ) -> None:
         self.limited_insertion = limited_insertion
         self.allow_factorable_insertions = allow_factorable_insertions

--- a/tilings/strategies/requirement_insertion.py
+++ b/tilings/strategies/requirement_insertion.py
@@ -400,8 +400,10 @@ class RequirementInsertionFactory(RequirementInsertionWithRestrictionFactory):
         extra_basis: Optional[List[Perm]] = None,
         limited_insertion: bool = True,
         ignore_parent: bool = False,
+        allow_factorable_insertions: bool = False,
     ) -> None:
         self.limited_insertion = limited_insertion
+        self.allow_factorable_insertions = allow_factorable_insertions
         super().__init__(maxreqlen, extra_basis, ignore_parent)
 
     def req_lists_to_insert(self, tiling: Tiling) -> Iterator[ListRequirement]:
@@ -414,7 +416,7 @@ class RequirementInsertionFactory(RequirementInsertionWithRestrictionFactory):
         )
         for length in range(1, self.maxreqlen + 1):
             for gp in obs_tiling.gridded_perms_of_length(length):
-                if len(gp.factors()) == 1 and all(
+                if (self.allow_factorable_insertions or len(gp.factors()) == 1) and all(
                     p not in gp.patt for p in self.extra_basis
                 ):
                     yield (GriddedPerm(gp.patt, gp.pos),)
@@ -440,6 +442,7 @@ class RequirementInsertionFactory(RequirementInsertionWithRestrictionFactory):
                 f"extra_basis={self.extra_basis!r}",
                 f"limited_insertion={self.limited_insertion}",
                 f"ignore_parent={self.ignore_parent}",
+                f"allow_factorable_insertions={self.allow_factorable_insertions}",
             ]
         )
         return f"{self.__class__.__name__}({args})"
@@ -447,6 +450,7 @@ class RequirementInsertionFactory(RequirementInsertionWithRestrictionFactory):
     def to_jsonable(self) -> dict:
         d: dict = super().to_jsonable()
         d["limited_insertion"] = self.limited_insertion
+        d["allow_factorable_insertions"] = self.allow_factorable_insertions
         return d
 
     @classmethod
@@ -458,10 +462,12 @@ class RequirementInsertionFactory(RequirementInsertionWithRestrictionFactory):
         d.pop("extra_basis")
         limited_insertion = d.pop("limited_insertion")
         maxreqlen = d.pop("maxreqlen")
+        allow_factorable_insertions = d.pop("allow_factorable_insertions")
         return cls(
             maxreqlen=maxreqlen,
             extra_basis=extra_basis,
             limited_insertion=limited_insertion,
+            allow_factorable_insertions=allow_factorable_insertions,
             **d,
         )
 


### PR DESCRIPTION
Testing plan: after merging the PR to show number of rules produced per strategy, try some runs with and without factorable requirement insertions, to see how much the universe is expanded.