### PR TITLE
fix k0 / k_0 typo in 1x1 eqs

### DIFF
--- a/tilings/strategies/verification.py
+++ b/tilings/strategies/verification.py
@@ -197,7 +197,7 @@ class OneByOneVerificationRule(VerificationRule[Tiling, GriddedPerm]):
         x_var = "x"
         if params:
             assert len(params) == 1
-            x_var += "*" + params[0].replace("_", "")
+            x_var += "*" + params[0]
         basis = [ob.patt for ob in tiling.obstructions]
         return Symbol(f"F_{Av(basis)}({x_var})")
 


### PR DESCRIPTION
Will require an update on CSS to work. 