### PR TITLE
Shift from spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ swapped around a fusable row or column.
 - `LocalVerificationStrategy` needs to be a `BasisAwareVerificationStrategy`
 - `PointJumping` maps component assumption to component assumptions.
 - `Tiling.all_symmetries` had a premature break statement that was removed
+- `shift_from_spec` method would previously fail if any tiling had two or 
+  more interleaving cells.
 
 ### Changed
 - `TileScopePack.make_tracked` will add the appropriate tracking methods for

--- a/tilings/algorithms/locally_factorable_shift.py
+++ b/tilings/algorithms/locally_factorable_shift.py
@@ -82,10 +82,10 @@ def expanded_spec(
         ver_strats=pack.ver_strats,
         name=pack.name,
     )
-    # pack = pack.remove_strategy(MonotoneTreeVerificationStrategy()).make_interleaving(
-    #     tracked=False, unions=False
-    # )
-    # pack = pack.remove_strategy(LocalVerificationStrategy())
+    pack = pack.remove_strategy(MonotoneTreeVerificationStrategy()).make_interleaving(
+        tracked=False, unions=False
+    )
+    pack = pack.remove_strategy(LocalVerificationStrategy())
     pack = pack.add_verification(NoBasisVerification(symmetries), apply_first=True)
     with TmpLoggingLevel(logging.WARN):
         css = CombinatorialSpecificationSearcher(tiling, pack)

--- a/tilings/algorithms/locally_factorable_shift.py
+++ b/tilings/algorithms/locally_factorable_shift.py
@@ -7,7 +7,7 @@ from comb_spec_searcher import (
     CombinatorialSpecification,
     CombinatorialSpecificationSearcher,
 )
-from comb_spec_searcher.strategies.constructor import CartesianProduct, DisjointUnion
+from comb_spec_searcher.strategies.constructor import DisjointUnion
 from comb_spec_searcher.strategies.rule import Rule, VerificationRule
 from comb_spec_searcher.strategies.strategy import VerificationStrategy
 from comb_spec_searcher.strategies.strategy_pack import StrategyPack
@@ -15,6 +15,7 @@ from comb_spec_searcher.typing import CSSstrategy
 from permuta import Av, Perm
 from tilings import GriddedPerm, Tiling
 from tilings.strategies.detect_components import CountComponent
+from tilings.strategies.factor import FactorStrategy
 
 __all__ = ["shift_from_spec"]
 
@@ -60,7 +61,31 @@ def expanded_spec(
     """
     Return a spec where any tiling that does not have the basis in one cell is
     verified.
+
+    A locally factorable tiling can always result in a spec where the
+    verified leaves are one by one if we remove the local verification
+    and monotone tree verification strategies and instead use the
+    interleaving factors. As we only care about the shift, we can
+    tailor our packs to find this.
     """
+    # pylint: disable=import-outside-toplevel
+    from tilings.strategies.verification import (
+        LocalVerificationStrategy,
+        MonotoneTreeVerificationStrategy,
+    )
+    from tilings.tilescope import TileScopePack
+
+    pack = TileScopePack(
+        initial_strats=pack.initial_strats,
+        inferral_strats=pack.inferral_strats,
+        expansion_strats=pack.expansion_strats,
+        ver_strats=pack.ver_strats,
+        name=pack.name,
+    )
+    # pack = pack.remove_strategy(MonotoneTreeVerificationStrategy()).make_interleaving(
+    #     tracked=False, unions=False
+    # )
+    # pack = pack.remove_strategy(LocalVerificationStrategy())
     pack = pack.add_verification(NoBasisVerification(symmetries), apply_first=True)
     with TmpLoggingLevel(logging.WARN):
         css = CombinatorialSpecificationSearcher(tiling, pack)
@@ -87,13 +112,11 @@ def shift_from_spec(
         elif t.dimensions == (1, 1):
             res = 0
         elif isinstance(rule, VerificationRule):
-            res = shift_from_spec(tiling, rule.pack(), symmetries)
-        elif isinstance(rule, Rule) and isinstance(
-            rule.constructor, (DisjointUnion, CountComponent)
-        ):
-            children_reliance = [traverse(c) for c in rule.children]
-            res = min((r for r in children_reliance if r is not None), default=None)
-        elif isinstance(rule, Rule) and isinstance(rule.constructor, CartesianProduct):
+            raise ValueError(
+                "this should be unreachable, looks like JP, HU "
+                "and CB misunderstood the code."
+            )
+        elif isinstance(rule, Rule) and isinstance(rule.strategy, FactorStrategy):
             min_points = [len(next(c.minimal_gridded_perms())) for c in rule.children]
             point_sum = sum(min_points)
             shifts = [point_sum - mpoint for mpoint in min_points]
@@ -102,6 +125,12 @@ def shift_from_spec(
                 (r + s for r, s in zip(children_reliance, shifts) if r is not None),
                 default=None,
             )
+        elif isinstance(rule, Rule) and isinstance(
+            rule.constructor, (DisjointUnion, CountComponent)
+        ):
+            children_reliance = [traverse(c) for c in rule.children]
+            res = min((r for r in children_reliance if r is not None), default=None)
+
         else:
             raise NotImplementedError(rule)
         traverse_cache[t] = res


### PR DESCRIPTION
`shift_from_spec` method would previously fail if any tiling had two or more interleaving cells.